### PR TITLE
feat(AspNetCore): add connection, auth, throttle infrastructure events (#6)

### DIFF
--- a/src/OtelEvents.AspNetCore/Events/HttpInfrastructureEvents.cs
+++ b/src/OtelEvents.AspNetCore/Events/HttpInfrastructureEvents.cs
@@ -1,0 +1,335 @@
+using System.Diagnostics.Metrics;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace OtelEvents.AspNetCore.Events;
+
+/// <summary>
+/// Pre-compiled [LoggerMessage] methods and metrics for HTTP infrastructure events.
+/// Maps to the aspnetcore.all.yaml schema (event IDs 10004–10006).
+/// These are SUPPLEMENTAL events — they fire alongside the standard operation events.
+/// </summary>
+/// <remarks>
+/// Event emission is defensive: all public methods catch exceptions internally
+/// to guarantee the middleware pipeline is never disrupted by telemetry failures.
+/// </remarks>
+internal static partial class HttpInfrastructureEvents
+{
+    // ─── Constants ──────────────────────────────────────────────────────
+
+    /// <summary>Maximum Retry-After value in milliseconds (1 hour).</summary>
+    private const long MaxRetryAfterMs = 3_600_000L;
+
+    /// <summary>Length of the identity hint hash prefix.</summary>
+    private const int IdentityHintLength = 8;
+
+    // ─── Meter & Instruments ────────────────────────────────────────────
+
+    private static readonly Meter s_meter = new("OtelEvents.AspNetCore.Infra", "1.0.0");
+
+    /// <summary>Counter: total HTTP connection failures.</summary>
+    internal static readonly Counter<long> ConnectionFailedCount =
+        s_meter.CreateCounter<long>(
+            "otel.http.connection.failed.count", "errors", "Total HTTP connection failures");
+
+    /// <summary>Counter: total HTTP authentication failures (401/403).</summary>
+    internal static readonly Counter<long> AuthFailedCount =
+        s_meter.CreateCounter<long>(
+            "otel.http.auth.failed.count", "errors", "Total HTTP authentication failures");
+
+    /// <summary>Counter: total HTTP throttle responses (429).</summary>
+    internal static readonly Counter<long> ThrottledCount =
+        s_meter.CreateCounter<long>(
+            "otel.http.throttled.count", "responses", "Total HTTP throttle responses");
+
+    // ─── Event: http.connection.failed (ID 10004) ───────────────────────
+
+    [LoggerMessage(
+        EventId = 10004,
+        EventName = "http.connection.failed",
+        Level = LogLevel.Error,
+        Message = "HTTP connection to {Endpoint} failed after {DurationMs}ms: {FailureReason}")]
+    private static partial void LogConnectionFailed(
+        ILogger logger,
+        string endpoint,
+        double durationMs,
+        string errorType,
+        string errorMessage,
+        string failureReason,
+        int? port);
+
+    /// <summary>
+    /// Emits the <c>http.connection.failed</c> event (ID 10004) and records metrics.
+    /// Defensive: never throws.
+    /// </summary>
+    internal static void EmitConnectionFailed(
+        ILogger logger,
+        string endpoint,
+        double durationMs,
+        HttpRequestException exception)
+    {
+        try
+        {
+            var failureReason = ClassifyFailureReason(exception);
+            var errorType = exception.GetType().Name;
+            var errorMessage = exception.Message;
+            var port = ExtractPort(endpoint);
+
+            LogConnectionFailed(logger, endpoint, durationMs, errorType, errorMessage, failureReason, port);
+
+            ConnectionFailedCount.Add(1,
+                new KeyValuePair<string, object?>("failureReason", failureReason));
+        }
+        catch
+        {
+            // Defensive: infrastructure event emission must NEVER throw
+        }
+    }
+
+    // ─── Event: http.auth.failed (ID 10005) ─────────────────────────────
+
+    [LoggerMessage(
+        EventId = 10005,
+        EventName = "http.auth.failed",
+        Level = LogLevel.Error,
+        Message = "HTTP authentication failed with {HttpStatusCode} using {AuthScheme}")]
+    private static partial void LogAuthFailed(
+        ILogger logger,
+        int httpStatusCode,
+        string authScheme,
+        string? identityHint);
+
+    /// <summary>
+    /// Emits the <c>http.auth.failed</c> event (ID 10005) and records metrics.
+    /// Defensive: never throws.
+    /// </summary>
+    internal static void EmitAuthFailed(
+        ILogger logger,
+        int httpStatusCode,
+        string? wwwAuthenticateHeader,
+        string? authorizationHeader)
+    {
+        try
+        {
+            var authScheme = ParseAuthScheme(wwwAuthenticateHeader);
+            var identityHint = ComputeIdentityHint(authorizationHeader);
+
+            LogAuthFailed(logger, httpStatusCode, authScheme, identityHint);
+
+            AuthFailedCount.Add(1,
+                new KeyValuePair<string, object?>("authScheme", authScheme),
+                new KeyValuePair<string, object?>("httpStatusCode", httpStatusCode));
+        }
+        catch
+        {
+            // Defensive: infrastructure event emission must NEVER throw
+        }
+    }
+
+    // ─── Event: http.throttled (ID 10006) ───────────────────────────────
+
+    [LoggerMessage(
+        EventId = 10006,
+        EventName = "http.throttled",
+        Level = LogLevel.Warning,
+        Message = "HTTP request throttled with {HttpStatusCode}, retry after {RetryAfterMs}ms")]
+    private static partial void LogThrottled(
+        ILogger logger,
+        int httpStatusCode,
+        long? retryAfterMs,
+        string? currentLimit);
+
+    /// <summary>
+    /// Emits the <c>http.throttled</c> event (ID 10006) and records metrics.
+    /// Defensive: never throws.
+    /// </summary>
+    internal static void EmitThrottled(
+        ILogger logger,
+        int httpStatusCode,
+        string? retryAfterHeader,
+        string? rateLimitHeader)
+    {
+        try
+        {
+            var retryAfterMs = ParseRetryAfterMs(retryAfterHeader);
+            var currentLimit = string.IsNullOrEmpty(rateLimitHeader) ? null : rateLimitHeader;
+
+            LogThrottled(logger, httpStatusCode, retryAfterMs, currentLimit);
+
+            ThrottledCount.Add(1);
+        }
+        catch
+        {
+            // Defensive: infrastructure event emission must NEVER throw
+        }
+    }
+
+    // ─── Classification Helpers ─────────────────────────────────────────
+
+    /// <summary>
+    /// Classifies the failure reason from an HttpRequestException's inner exception.
+    /// </summary>
+    internal static string ClassifyFailureReason(HttpRequestException exception)
+    {
+        // Check inner exception for socket errors
+        if (exception.InnerException is System.Net.Sockets.SocketException socketEx)
+        {
+            return socketEx.SocketErrorCode switch
+            {
+                System.Net.Sockets.SocketError.ConnectionRefused => "ConnectionRefused",
+                System.Net.Sockets.SocketError.HostNotFound => "DnsResolutionFailed",
+                System.Net.Sockets.SocketError.HostUnreachable => "ConnectionRefused",
+                System.Net.Sockets.SocketError.TimedOut => "Timeout",
+                _ => "Unknown"
+            };
+        }
+
+        // Check for TLS/SSL exceptions
+        if (exception.InnerException is System.Security.Authentication.AuthenticationException)
+        {
+            return "TlsHandshakeFailed";
+        }
+
+        // Check for timeout
+        if (exception.InnerException is TaskCanceledException or OperationCanceledException)
+        {
+            return "Timeout";
+        }
+
+        // Check message hints
+        var message = exception.Message;
+        if (message.Contains("SSL", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("TLS", StringComparison.OrdinalIgnoreCase))
+        {
+            return "TlsHandshakeFailed";
+        }
+
+        if (message.Contains("DNS", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("name resolution", StringComparison.OrdinalIgnoreCase))
+        {
+            return "DnsResolutionFailed";
+        }
+
+        if (message.Contains("timed out", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("timeout", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Timeout";
+        }
+
+        return "Unknown";
+    }
+
+    /// <summary>
+    /// Parses the auth scheme from WWW-Authenticate header.
+    /// Returns "Unknown" when the header is absent or unrecognized.
+    /// </summary>
+    internal static string ParseAuthScheme(string? wwwAuthenticateHeader)
+    {
+        if (string.IsNullOrEmpty(wwwAuthenticateHeader))
+        {
+            return "Unknown";
+        }
+
+        // The header format is: scheme [realm="...", ...]
+        // We only need the first token
+        var spaceIndex = wwwAuthenticateHeader.IndexOf(' ', StringComparison.Ordinal);
+        var scheme = spaceIndex > 0
+            ? wwwAuthenticateHeader[..spaceIndex]
+            : wwwAuthenticateHeader;
+
+        return scheme switch
+        {
+            "Bearer" => "Bearer",
+            "SharedKey" => "SharedKey",
+            "Basic" => "Basic",
+            _ => scheme // Return as-is for recognized non-standard schemes
+        };
+    }
+
+    /// <summary>
+    /// Computes a privacy-safe identity hint from the Authorization header.
+    /// Returns the first 8 characters of a SHA-256 hash — NEVER the raw credential.
+    /// Returns null when no Authorization header is present.
+    /// </summary>
+    internal static string? ComputeIdentityHint(string? authorizationHeader)
+    {
+        if (string.IsNullOrEmpty(authorizationHeader))
+        {
+            return null;
+        }
+
+        var bytes = Encoding.UTF8.GetBytes(authorizationHeader);
+        var hash = SHA256.HashData(bytes);
+        var hex = Convert.ToHexString(hash);
+
+        return hex[..IdentityHintLength].ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Parses the Retry-After header value into milliseconds.
+    /// Supports both seconds (integer) and HTTP-date formats.
+    /// Clamps result to [0, 3600000] (max 1 hour).
+    /// Returns null when the header is absent or unparseable.
+    /// </summary>
+    internal static long? ParseRetryAfterMs(string? retryAfterHeader)
+    {
+        if (string.IsNullOrEmpty(retryAfterHeader))
+        {
+            return null;
+        }
+
+        // Try parsing as integer seconds first
+        if (long.TryParse(retryAfterHeader, out var seconds))
+        {
+            var ms = seconds * 1000L;
+            return ClampRetryAfterMs(ms);
+        }
+
+        // Try parsing as HTTP-date
+        if (DateTimeOffset.TryParse(retryAfterHeader, out var retryDate))
+        {
+            var delta = retryDate - DateTimeOffset.UtcNow;
+            var ms = (long)delta.TotalMilliseconds;
+            return ClampRetryAfterMs(Math.Max(0, ms));
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Clamps a retry-after value to the allowed range [0, 3600000].
+    /// </summary>
+    private static long ClampRetryAfterMs(long ms)
+    {
+        if (ms < 0) return 0;
+        if (ms > MaxRetryAfterMs) return MaxRetryAfterMs;
+        return ms;
+    }
+
+    /// <summary>
+    /// Extracts a port number from an endpoint string, if present.
+    /// </summary>
+    private static int? ExtractPort(string endpoint)
+    {
+        // Try to find :port at the end of the endpoint
+        var lastColon = endpoint.LastIndexOf(':');
+        if (lastColon > 0 && lastColon < endpoint.Length - 1)
+        {
+            var portStr = endpoint[(lastColon + 1)..];
+            // Remove any trailing path
+            var slashIndex = portStr.IndexOf('/', StringComparison.Ordinal);
+            if (slashIndex >= 0)
+            {
+                portStr = portStr[..slashIndex];
+            }
+
+            if (int.TryParse(portStr, out var port) && port > 0 && port <= 65535)
+            {
+                return port;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/OtelEvents.AspNetCore/OtelEvents.AspNetCore.csproj
+++ b/src/OtelEvents.AspNetCore/OtelEvents.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <NoWarn>CA1062;CA1822;CA2000;CA2007;CA2227;SYSLIB1015</NoWarn>
+    <NoWarn>CA1031;CA1062;CA1308;CA1822;CA2000;CA2007;CA2227;SYSLIB1015</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OtelEvents.AspNetCore/OtelEventsAspNetCoreMiddleware.cs
+++ b/src/OtelEvents.AspNetCore/OtelEventsAspNetCoreMiddleware.cs
@@ -87,6 +87,12 @@ internal sealed class OtelEventsAspNetCoreMiddleware : IMiddleware
                 durationMs: sw.Elapsed.TotalMilliseconds,
                 contentLength: context.Response.ContentLength,
                 requestId: context.TraceIdentifier);
+
+            // Emit supplemental infrastructure events based on response status code
+            if (_options.EmitInfrastructureEvents)
+            {
+                EmitResponseInfrastructureEvents(context);
+            }
         }
         catch (Exception ex)
         {
@@ -105,6 +111,12 @@ internal sealed class OtelEventsAspNetCoreMiddleware : IMiddleware
                 errorType: ex.GetType().Name,
                 requestId: context.TraceIdentifier,
                 exception: ex);
+
+            // Emit supplemental infrastructure events for exceptions
+            if (_options.EmitInfrastructureEvents)
+            {
+                EmitExceptionInfrastructureEvents(context, ex, sw.Elapsed.TotalMilliseconds);
+            }
 
             throw; // Re-throw — middleware observes, never swallows
         }
@@ -228,5 +240,66 @@ internal sealed class OtelEventsAspNetCoreMiddleware : IMiddleware
         // We need a stable event ID for the causal scope root.
         // Generate a new UUID v7 event ID for the causal scope.
         return Uuid7.FormatEventId();
+    }
+
+    // ─── Infrastructure Event Helpers ───────────────────────────────────
+
+    /// <summary>
+    /// Emits supplemental infrastructure events based on the HTTP response status code.
+    /// Handles 401/403 (auth failed) and 429 (throttled) responses.
+    /// Defensive: never throws — wrapped in try-catch.
+    /// </summary>
+    private void EmitResponseInfrastructureEvents(HttpContext context)
+    {
+        try
+        {
+            var statusCode = context.Response.StatusCode;
+
+            if (statusCode is 401 or 403)
+            {
+                HttpInfrastructureEvents.EmitAuthFailed(
+                    _logger,
+                    httpStatusCode: statusCode,
+                    wwwAuthenticateHeader: context.Response.Headers["WWW-Authenticate"].ToString(),
+                    authorizationHeader: context.Request.Headers.Authorization.ToString());
+            }
+            else if (statusCode == 429)
+            {
+                HttpInfrastructureEvents.EmitThrottled(
+                    _logger,
+                    httpStatusCode: statusCode,
+                    retryAfterHeader: context.Response.Headers["Retry-After"].ToString(),
+                    rateLimitHeader: context.Response.Headers["X-RateLimit-Limit"].ToString());
+            }
+        }
+        catch
+        {
+            // Defensive: infrastructure event emission must NEVER throw
+        }
+    }
+
+    /// <summary>
+    /// Emits supplemental infrastructure events for exceptions.
+    /// Only emits http.connection.failed for HttpRequestException.
+    /// Defensive: never throws — wrapped in try-catch.
+    /// </summary>
+    private void EmitExceptionInfrastructureEvents(HttpContext context, Exception exception, double durationMs)
+    {
+        try
+        {
+            if (exception is HttpRequestException httpEx)
+            {
+                var endpoint = GetRawPath(context);
+                HttpInfrastructureEvents.EmitConnectionFailed(
+                    _logger,
+                    endpoint: endpoint,
+                    durationMs: durationMs,
+                    exception: httpEx);
+            }
+        }
+        catch
+        {
+            // Defensive: infrastructure event emission must NEVER throw
+        }
     }
 }

--- a/src/OtelEvents.AspNetCore/OtelEventsAspNetCoreOptions.cs
+++ b/src/OtelEvents.AspNetCore/OtelEventsAspNetCoreOptions.cs
@@ -55,4 +55,12 @@ public sealed class OtelEventsAspNetCoreOptions
     /// Default: 256.
     /// </summary>
     public int MaxPathLength { get; set; } = 256;
+
+    /// <summary>
+    /// Emit supplemental infrastructure events for connection failures (10004),
+    /// authentication failures (10005), and throttling (10006).
+    /// These events fire IN ADDITION to the standard operation events (10001–10003).
+    /// Default: true.
+    /// </summary>
+    public bool EmitInfrastructureEvents { get; set; } = true;
 }

--- a/src/OtelEvents.AspNetCore/Schemas/aspnetcore.all.yaml
+++ b/src/OtelEvents.AspNetCore/Schemas/aspnetcore.all.yaml
@@ -59,6 +59,38 @@ fields:
     description: "Exception type name for failed requests"
     index: true
 
+  failureReason:
+    type: string
+    description: "Connection failure reason (ConnectionRefused, DnsResolutionFailed, TlsHandshakeFailed, Timeout, Unknown)"
+    index: true
+
+  errorMessage:
+    type: string
+    description: "Error message from the exception"
+
+  port:
+    type: int
+    description: "Target port number, when available"
+
+  authScheme:
+    type: string
+    description: "Authentication scheme (Bearer, SAS, SharedKey, Anonymous, Unknown)"
+    index: true
+
+  identityHint:
+    type: string
+    description: "First 8 characters of SHA-256 hash of the credential — NEVER raw credential"
+    sensitivity: pii_hash
+
+  retryAfterMs:
+    type: long
+    description: "Retry-After value in milliseconds, parsed from header, clamped to [0, 3600000]"
+    unit: "ms"
+
+  currentLimit:
+    type: string
+    description: "Current rate limit value from X-RateLimit-Limit header"
+
 events:
   http.request.received:
     id: 10001
@@ -184,3 +216,95 @@ events:
       - http
       - aspnetcore
       - error
+
+  http.connection.failed:
+    id: 10004
+    severity: ERROR
+    description: "An HTTP connection failed (connection refused, DNS resolution failed, TLS handshake failed, or timeout)."
+    message: "HTTP connection to {endpoint} failed after {durationMs}ms: {failureReason}"
+    fields:
+      endpoint:
+        type: string
+        description: "Target endpoint URL or path"
+        required: true
+      durationMs:
+        ref: durationMs
+        required: true
+      errorType:
+        ref: errorType
+        required: true
+      errorMessage:
+        ref: errorMessage
+        required: true
+      failureReason:
+        ref: failureReason
+        required: true
+      port:
+        ref: port
+        required: false
+    metrics:
+      otel.http.connection.failed.count:
+        type: counter
+        unit: "errors"
+        description: "Total HTTP connection failures"
+        labels:
+          - failureReason
+    tags:
+      - http
+      - aspnetcore
+      - infrastructure
+      - error
+
+  http.auth.failed:
+    id: 10005
+    severity: ERROR
+    description: "An HTTP request failed authentication or authorization (401/403 response)."
+    message: "HTTP authentication failed with {httpStatusCode} using {authScheme}"
+    fields:
+      httpStatusCode:
+        ref: httpStatusCode
+        required: true
+      authScheme:
+        ref: authScheme
+        required: true
+      identityHint:
+        ref: identityHint
+        required: false
+    metrics:
+      otel.http.auth.failed.count:
+        type: counter
+        unit: "errors"
+        description: "Total HTTP authentication failures"
+        labels:
+          - authScheme
+          - httpStatusCode
+    tags:
+      - http
+      - aspnetcore
+      - infrastructure
+      - security
+
+  http.throttled:
+    id: 10006
+    severity: WARN
+    description: "An HTTP request was throttled (429 Too Many Requests response)."
+    message: "HTTP request throttled with {httpStatusCode}, retry after {retryAfterMs}ms"
+    fields:
+      httpStatusCode:
+        ref: httpStatusCode
+        required: true
+      retryAfterMs:
+        ref: retryAfterMs
+        required: false
+      currentLimit:
+        ref: currentLimit
+        required: false
+    metrics:
+      otel.http.throttled.count:
+        type: counter
+        unit: "responses"
+        description: "Total HTTP throttle responses"
+    tags:
+      - http
+      - aspnetcore
+      - infrastructure

--- a/tests/OtelEvents.AspNetCore.Tests/HttpInfrastructureEventsTests.cs
+++ b/tests/OtelEvents.AspNetCore.Tests/HttpInfrastructureEventsTests.cs
@@ -1,0 +1,668 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OtelEvents.AspNetCore;
+using OtelEvents.AspNetCore.Events;
+using OtelEvents.Causality;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace OtelEvents.AspNetCore.Tests;
+
+/// <summary>
+/// TDD tests for HTTP infrastructure events (IDs 10004–10006).
+/// Validates http.connection.failed, http.auth.failed, and http.throttled events
+/// emitted as SUPPLEMENTAL events alongside the existing operation events.
+/// </summary>
+public class HttpInfrastructureEventsTests : IAsyncDisposable
+{
+    // ─── Test Infrastructure ────────────────────────────────────────────
+
+    /// <summary>All OtelEvents event names including infrastructure events.</summary>
+    private static readonly HashSet<string> AllOtelEventNames =
+    [
+        "http.request.received",
+        "http.request.completed",
+        "http.request.failed",
+        "http.connection.failed",
+        "http.auth.failed",
+        "http.throttled"
+    ];
+
+    /// <summary>Infrastructure event names only.</summary>
+    private static readonly HashSet<string> InfraEventNames =
+    [
+        "http.connection.failed",
+        "http.auth.failed",
+        "http.throttled"
+    ];
+
+    private static List<TestLogRecord> GetOtelEvents(TestLogExporter exporter) =>
+        exporter.LogRecords.Where(r => r.EventName is not null && AllOtelEventNames.Contains(r.EventName)).ToList();
+
+    private static List<TestLogRecord> GetInfraEvents(TestLogExporter exporter) =>
+        exporter.LogRecords.Where(r => r.EventName is not null && InfraEventNames.Contains(r.EventName)).ToList();
+
+    /// <summary>
+    /// Creates a TestServer with configurable endpoints and infrastructure event support.
+    /// </summary>
+    private static async Task<(IHost Host, TestLogExporter Exporter)> CreateTestHost(
+        Action<OtelEventsAspNetCoreOptions>? configureOptions = null,
+        Action<IEndpointRouteBuilder>? configureEndpoints = null)
+    {
+        var exporter = new TestLogExporter();
+
+        var host = await new HostBuilder()
+            .ConfigureWebHost(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                webBuilder.ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                    logging.AddOpenTelemetry(options =>
+                    {
+                        options.IncludeFormattedMessage = true;
+                        options.ParseStateValues = true;
+                        options.AddProcessor(new OtelEventsCausalityProcessor());
+                        options.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+                    });
+                });
+                webBuilder.ConfigureServices(services =>
+                {
+                    services.AddRouting();
+                    services.AddOtelEventsAspNetCore(configureOptions ?? (_ => { }));
+                });
+                webBuilder.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(configureEndpoints ?? (endpoints =>
+                    {
+                        endpoints.MapGet("/api/ok", async context =>
+                        {
+                            await context.Response.WriteAsync("OK");
+                        });
+
+                        // 401 Unauthorized
+                        endpoints.MapGet("/api/unauthorized", context =>
+                        {
+                            context.Response.StatusCode = 401;
+                            context.Response.Headers["WWW-Authenticate"] = "Bearer";
+                            return context.Response.WriteAsync("Unauthorized");
+                        });
+
+                        // 403 Forbidden
+                        endpoints.MapGet("/api/forbidden", context =>
+                        {
+                            context.Response.StatusCode = 403;
+                            context.Response.Headers["WWW-Authenticate"] = "Bearer realm=\"api\"";
+                            return context.Response.WriteAsync("Forbidden");
+                        });
+
+                        // 429 Too Many Requests
+                        endpoints.MapGet("/api/throttled", context =>
+                        {
+                            context.Response.StatusCode = 429;
+                            context.Response.Headers["Retry-After"] = "30";
+                            return context.Response.WriteAsync("Too Many Requests");
+                        });
+
+                        // 429 with absolute date Retry-After
+                        endpoints.MapGet("/api/throttled-date", context =>
+                        {
+                            context.Response.StatusCode = 429;
+                            var retryDate = DateTimeOffset.UtcNow.AddSeconds(60);
+                            context.Response.Headers["Retry-After"] = retryDate.ToString("R");
+                            return context.Response.WriteAsync("Too Many Requests");
+                        });
+
+                        // 429 without Retry-After header
+                        endpoints.MapGet("/api/throttled-no-retry", context =>
+                        {
+                            context.Response.StatusCode = 429;
+                            return context.Response.WriteAsync("Too Many Requests");
+                        });
+
+                        // 429 with X-RateLimit-Limit header
+                        endpoints.MapGet("/api/throttled-with-limit", context =>
+                        {
+                            context.Response.StatusCode = 429;
+                            context.Response.Headers["Retry-After"] = "10";
+                            context.Response.Headers["X-RateLimit-Limit"] = "100";
+                            return context.Response.WriteAsync("Too Many Requests");
+                        });
+
+                        // Endpoint that throws HttpRequestException (connection failed)
+                        endpoints.MapGet("/api/connection-fail", _ =>
+                        {
+                            throw new HttpRequestException(
+                                "Connection refused",
+                                new System.Net.Sockets.SocketException((int)System.Net.Sockets.SocketError.ConnectionRefused),
+                                System.Net.HttpStatusCode.ServiceUnavailable);
+                        });
+
+                        // Endpoint that throws generic exception (not HttpRequestException)
+                        endpoints.MapGet("/api/generic-throw", _ =>
+                        {
+                            throw new InvalidOperationException("Something broke");
+                        });
+
+                        // 401 with SAS token auth
+                        endpoints.MapGet("/api/unauthorized-sas", context =>
+                        {
+                            context.Response.StatusCode = 401;
+                            return context.Response.WriteAsync("Unauthorized");
+                        });
+
+                        // 401 with SharedKey auth
+                        endpoints.MapGet("/api/unauthorized-sharedkey", context =>
+                        {
+                            context.Response.StatusCode = 401;
+                            context.Response.Headers["WWW-Authenticate"] = "SharedKey";
+                            return context.Response.WriteAsync("Unauthorized");
+                        });
+
+                        // 429 with extremely large retry-after (should be clamped)
+                        endpoints.MapGet("/api/throttled-huge-retry", context =>
+                        {
+                            context.Response.StatusCode = 429;
+                            context.Response.Headers["Retry-After"] = "999999";
+                            return context.Response.WriteAsync("Too Many Requests");
+                        });
+                    }));
+                });
+            })
+            .StartAsync();
+
+        return (host, exporter);
+    }
+
+    private readonly List<IHost> _hosts = [];
+
+    private async Task<(HttpClient Client, TestLogExporter Exporter)> CreateClient(
+        Action<OtelEventsAspNetCoreOptions>? configureOptions = null,
+        Action<IEndpointRouteBuilder>? configureEndpoints = null)
+    {
+        var (host, exporter) = await CreateTestHost(configureOptions, configureEndpoints);
+        _hosts.Add(host);
+        var client = host.GetTestClient();
+        return (client, exporter);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var host in _hosts)
+        {
+            await host.StopAsync();
+            host.Dispose();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // §1 — EmitInfrastructureEvents Option
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void EmitInfrastructureEvents_DefaultsToTrue()
+    {
+        var options = new OtelEventsAspNetCoreOptions();
+        Assert.True(options.EmitInfrastructureEvents);
+    }
+
+    [Fact]
+    public async Task InfraEvents_Disabled_NoInfraEventsEmitted()
+    {
+        // Arrange — disable infra events
+        var (client, exporter) = await CreateClient(options =>
+        {
+            options.EmitInfrastructureEvents = false;
+        });
+
+        // Act — 401 response
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert — operation event fires, but NO infra event
+        exporter.AssertEventEmitted("http.request.completed");
+        Assert.Empty(GetInfraEvents(exporter));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // §2 — http.auth.failed (10005) — 401/403 Response
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task AuthFailed_401_EmitsAuthFailedEvent()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert — SUPPLEMENTAL: both completed + auth.failed
+        exporter.AssertEventEmitted("http.request.completed");
+        exporter.AssertEventEmitted("http.auth.failed");
+    }
+
+    [Fact]
+    public async Task AuthFailed_403_EmitsAuthFailedEvent()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/forbidden");
+
+        // Assert
+        exporter.AssertEventEmitted("http.request.completed");
+        exporter.AssertEventEmitted("http.auth.failed");
+    }
+
+    [Fact]
+    public async Task AuthFailed_HasCorrectEventId()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert
+        var record = exporter.AssertSingle("http.auth.failed");
+        Assert.Equal(10005, record.EventId.Id);
+        Assert.Equal("http.auth.failed", record.EventId.Name);
+    }
+
+    [Fact]
+    public async Task AuthFailed_HasErrorLogLevel()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert
+        var record = exporter.AssertSingle("http.auth.failed");
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+    }
+
+    [Fact]
+    public async Task AuthFailed_CapturesStatusCode()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert
+        var record = exporter.AssertSingle("http.auth.failed");
+        record.AssertAttribute("HttpStatusCode", 401);
+    }
+
+    [Fact]
+    public async Task AuthFailed_CapturesAuthScheme_Bearer()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert — WWW-Authenticate: Bearer → authScheme = "Bearer"
+        var record = exporter.AssertSingle("http.auth.failed");
+        record.AssertAttribute("AuthScheme", "Bearer");
+    }
+
+    [Fact]
+    public async Task AuthFailed_CapturesAuthScheme_Unknown_WhenNoHeader()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — SAS endpoint returns 401 without WWW-Authenticate
+        await client.GetAsync("/api/unauthorized-sas");
+
+        // Assert
+        var record = exporter.AssertSingle("http.auth.failed");
+        record.AssertAttribute("AuthScheme", "Unknown");
+    }
+
+    [Fact]
+    public async Task AuthFailed_CapturesIdentityHint_HashNotRaw()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", "my-secret-token-12345");
+
+        // Act
+        await client.GetAsync("/api/unauthorized");
+
+        // Assert — identityHint should be first 8 chars of SHA-256 hash, NEVER raw credential
+        var record = exporter.AssertSingle("http.auth.failed");
+        Assert.True(record.Attributes.ContainsKey("identityHint"),
+            $"Should capture identityHint. Available: {string.Join(", ", record.Attributes.Keys)}");
+        var hint = record.Attributes["identityHint"] as string;
+        Assert.NotNull(hint);
+        Assert.Equal(8, hint.Length);
+        // MUST NOT contain the raw token
+        Assert.DoesNotContain("my-secret-token", hint);
+    }
+
+    [Fact]
+    public async Task AuthFailed_200Response_NoAuthFailedEvent()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — 200 OK, should NOT emit auth.failed
+        await client.GetAsync("/api/ok");
+
+        // Assert
+        Assert.DoesNotContain(exporter.LogRecords, r => r.EventName == "http.auth.failed");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // §3 — http.throttled (10006) — 429 Response
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Throttled_429_EmitsThrottledEvent()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/throttled");
+
+        // Assert — SUPPLEMENTAL: both completed + throttled
+        exporter.AssertEventEmitted("http.request.completed");
+        exporter.AssertEventEmitted("http.throttled");
+    }
+
+    [Fact]
+    public async Task Throttled_HasCorrectEventId()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/throttled");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        Assert.Equal(10006, record.EventId.Id);
+        Assert.Equal("http.throttled", record.EventId.Name);
+    }
+
+    [Fact]
+    public async Task Throttled_HasWarningLogLevel()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/throttled");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        Assert.Equal(LogLevel.Warning, record.LogLevel);
+    }
+
+    [Fact]
+    public async Task Throttled_CapturesStatusCode()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await client.GetAsync("/api/throttled");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        record.AssertAttribute("HttpStatusCode", 429);
+    }
+
+    [Fact]
+    public async Task Throttled_CapturesRetryAfterMs_FromSeconds()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — Retry-After: 30 → 30000ms
+        await client.GetAsync("/api/throttled");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        record.AssertAttribute("RetryAfterMs", 30000L);
+    }
+
+    [Fact]
+    public async Task Throttled_RetryAfterMs_Null_WhenNoHeader()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — no Retry-After header
+        await client.GetAsync("/api/throttled-no-retry");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        Assert.True(record.Attributes.ContainsKey("RetryAfterMs"));
+        Assert.Null(record.Attributes["RetryAfterMs"]);
+    }
+
+    [Fact]
+    public async Task Throttled_RetryAfterMs_ClampedToMax()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — Retry-After: 999999 → clamped to 3600000 (1 hour)
+        await client.GetAsync("/api/throttled-huge-retry");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        record.AssertAttribute("RetryAfterMs", 3600000L);
+    }
+
+    [Fact]
+    public async Task Throttled_CapturesCurrentLimit()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — X-RateLimit-Limit: 100
+        await client.GetAsync("/api/throttled-with-limit");
+
+        // Assert
+        var record = exporter.AssertSingle("http.throttled");
+        record.AssertAttribute("currentLimit", "100");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // §4 — http.connection.failed (10004) — HttpRequestException
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task ConnectionFailed_EmitsConnectionFailedEvent()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — HttpRequestException
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await client.GetAsync("/api/connection-fail"));
+
+        // Assert — SUPPLEMENTAL: both request.failed + connection.failed
+        exporter.AssertEventEmitted("http.request.failed");
+        exporter.AssertEventEmitted("http.connection.failed");
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_HasCorrectEventId()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await client.GetAsync("/api/connection-fail"));
+
+        // Assert
+        var record = exporter.AssertSingle("http.connection.failed");
+        Assert.Equal(10004, record.EventId.Id);
+        Assert.Equal("http.connection.failed", record.EventId.Name);
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_HasErrorLogLevel()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await client.GetAsync("/api/connection-fail"));
+
+        // Assert
+        var record = exporter.AssertSingle("http.connection.failed");
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesEndpoint()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await client.GetAsync("/api/connection-fail"));
+
+        // Assert
+        var record = exporter.AssertSingle("http.connection.failed");
+        Assert.True(record.Attributes.ContainsKey("Endpoint"),
+            "Should capture endpoint");
+        var endpoint = record.Attributes["Endpoint"] as string;
+        Assert.NotNull(endpoint);
+        Assert.Contains("/api/connection-fail", endpoint);
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesDurationMs()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await client.GetAsync("/api/connection-fail"));
+
+        // Assert
+        var record = exporter.AssertSingle("http.connection.failed");
+        Assert.True(record.Attributes.ContainsKey("DurationMs"));
+        var durationMs = (double)record.Attributes["DurationMs"]!;
+        Assert.True(durationMs >= 0);
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesFailureReason_ConnectionRefused()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await client.GetAsync("/api/connection-fail"));
+
+        // Assert
+        var record = exporter.AssertSingle("http.connection.failed");
+        record.AssertAttribute("FailureReason", "ConnectionRefused");
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_NonHttpRequestException_NoConnectionFailedEvent()
+    {
+        // Arrange
+        var (client, exporter) = await CreateClient();
+
+        // Act — generic exception, not HttpRequestException
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await client.GetAsync("/api/generic-throw"));
+
+        // Assert — http.request.failed YES, http.connection.failed NO
+        exporter.AssertEventEmitted("http.request.failed");
+        Assert.DoesNotContain(exporter.LogRecords, r => r.EventName == "http.connection.failed");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // §5 — Defensive Behavior
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task InfraEvents_NeverThrow_OnEventEmission()
+    {
+        // Arrange — this test verifies the middleware doesn't break even when
+        // infrastructure event emission encounters edge cases.
+        // A normal request should complete successfully regardless.
+        var (client, exporter) = await CreateClient();
+
+        // Act — 200 OK
+        var response = await client.GetAsync("/api/ok");
+
+        // Assert — request succeeds, no infra events for 200
+        Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        Assert.Empty(GetInfraEvents(exporter));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // §6 — Schema Verification
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void EmbeddedSchema_ContainsInfrastructureEvents()
+    {
+        // Arrange
+        var assembly = typeof(OtelEventsAspNetCoreOptions).Assembly;
+        using var stream = assembly.GetManifestResourceStream("OtelEvents.AspNetCore.aspnetcore.all.yaml")!;
+        using var reader = new StreamReader(stream);
+
+        // Act
+        var content = reader.ReadToEnd();
+
+        // Assert — infrastructure events in schema
+        Assert.Contains("http.connection.failed", content);
+        Assert.Contains("http.auth.failed", content);
+        Assert.Contains("http.throttled", content);
+        Assert.Contains("id: 10004", content);
+        Assert.Contains("id: 10005", content);
+        Assert.Contains("id: 10006", content);
+    }
+
+    [Fact]
+    public void EmbeddedSchema_ContainsInfrastructureFields()
+    {
+        // Arrange
+        var assembly = typeof(OtelEventsAspNetCoreOptions).Assembly;
+        using var stream = assembly.GetManifestResourceStream("OtelEvents.AspNetCore.aspnetcore.all.yaml")!;
+        using var reader = new StreamReader(stream);
+
+        // Act
+        var content = reader.ReadToEnd();
+
+        // Assert — infrastructure-specific field definitions
+        Assert.Contains("failureReason", content);
+        Assert.Contains("authScheme", content);
+        Assert.Contains("identityHint", content);
+        Assert.Contains("retryAfterMs", content);
+        Assert.Contains("currentLimit", content);
+    }
+}


### PR DESCRIPTION
Adds 3 infrastructure events to OtelEvents.AspNetCore:
- `http.connection.failed` (10004) — DNS, TLS, connection refused
- `http.auth.failed` (10005) — 401/403 with hashed identity hint
- `http.throttled` (10006) — 429 with retry-after parsing

29 new tests. EmitInfrastructureEvents option (default: true). Part of #6.