### PR TITLE
feat(Storage): add connection, auth, throttle infrastructure events (#6)

### DIFF
--- a/src/OtelEvents.Azure.Storage/Events/StorageInfrastructureEvents.cs
+++ b/src/OtelEvents.Azure.Storage/Events/StorageInfrastructureEvents.cs
@@ -1,0 +1,327 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+
+// Explicit aliases to avoid namespace collision with OtelEvents.Azure
+using RequestFailedException = global::Azure.RequestFailedException;
+using AzureRequest = global::Azure.Core.Request;
+using AzureHttpMessage = global::Azure.Core.HttpMessage;
+
+namespace OtelEvents.Azure.Storage.Events;
+
+/// <summary>
+/// Pre-compiled [LoggerMessage] methods and metrics for Azure Storage infrastructure events.
+/// Maps to the azure-storage.all.yaml schema (event IDs 10308–10310).
+/// </summary>
+/// <remarks>
+/// Infrastructure events provide deeper diagnostics by classifying
+/// <see cref="Azure.RequestFailedException"/> into connection, authentication,
+/// and throttling categories. They are supplemental — the regular error event
+/// (e.g., storage.blob.failed) is still emitted alongside.
+/// </remarks>
+internal static partial class StorageInfrastructureEvents
+{
+    // ─── Meter & Instruments ────────────────────────────────────────────
+
+    private static readonly Meter s_meter = new("OtelEvents.Azure.Storage.Infra", "1.0.0");
+
+    /// <summary>Counter: total connection failures.</summary>
+    internal static readonly Counter<long> ConnectionFailedCount =
+        s_meter.CreateCounter<long>(
+            "otel.storage.connection.failed.count", "failures", "Total connection failures");
+
+    /// <summary>Counter: total auth failures.</summary>
+    internal static readonly Counter<long> AuthFailedCount =
+        s_meter.CreateCounter<long>(
+            "otel.storage.auth.failed.count", "failures", "Total auth failures");
+
+    /// <summary>Counter: total throttling events.</summary>
+    internal static readonly Counter<long> ThrottledCount =
+        s_meter.CreateCounter<long>(
+            "otel.storage.throttled.count", "events", "Total throttling events");
+
+    // ─── Event: storage.connection.failed (ID 10308) ────────────────────
+
+    [LoggerMessage(
+        EventId = 10308,
+        EventName = "storage.connection.failed",
+        Level = LogLevel.Error,
+        Message = "Storage connection to {endpoint} failed after {durationMs}ms: {failureReason}")]
+    private static partial void LogStorageConnectionFailed(
+        ILogger logger,
+        Exception? exception,
+        string endpoint,
+        string storageAccountName,
+        double durationMs,
+        string errorType,
+        string errorMessage,
+        string failureReason);
+
+    /// <summary>
+    /// Emits the <c>storage.connection.failed</c> event (ID 10308) and records metrics.
+    /// </summary>
+    internal static void StorageConnectionFailed(
+        this ILogger logger,
+        string endpoint,
+        string storageAccountName,
+        double durationMs,
+        string errorType,
+        string errorMessage,
+        string failureReason,
+        Exception? exception = null)
+    {
+        LogStorageConnectionFailed(logger, exception, endpoint, storageAccountName,
+            durationMs, errorType, errorMessage, failureReason);
+
+        ConnectionFailedCount.Add(1,
+            new KeyValuePair<string, object?>("storageAccountName", storageAccountName));
+    }
+
+    // ─── Event: storage.auth.failed (ID 10309) ──────────────────────────
+
+    [LoggerMessage(
+        EventId = 10309,
+        EventName = "storage.auth.failed",
+        Level = LogLevel.Error,
+        Message = "Storage auth failed for {storageAccountName} with {httpStatusCode} ({authScheme})")]
+    private static partial void LogStorageAuthFailed(
+        ILogger logger,
+        Exception? exception,
+        int httpStatusCode,
+        string storageAccountName,
+        string authScheme,
+        string? identityHint);
+
+    /// <summary>
+    /// Emits the <c>storage.auth.failed</c> event (ID 10309) and records metrics.
+    /// </summary>
+    internal static void StorageAuthFailed(
+        this ILogger logger,
+        int httpStatusCode,
+        string storageAccountName,
+        string authScheme,
+        string? identityHint,
+        Exception? exception = null)
+    {
+        LogStorageAuthFailed(logger, exception, httpStatusCode, storageAccountName,
+            authScheme, identityHint);
+
+        AuthFailedCount.Add(1,
+            new KeyValuePair<string, object?>("storageAccountName", storageAccountName),
+            new KeyValuePair<string, object?>("authScheme", authScheme));
+    }
+
+    // ─── Event: storage.throttled (ID 10310) ────────────────────────────
+
+    [LoggerMessage(
+        EventId = 10310,
+        EventName = "storage.throttled",
+        Level = LogLevel.Warning,
+        Message = "Storage request to {storageAccountName} was throttled ({httpStatusCode})")]
+    private static partial void LogStorageThrottled(
+        ILogger logger,
+        Exception? exception,
+        int httpStatusCode,
+        string storageAccountName,
+        long? retryAfterMs,
+        string? currentLimit);
+
+    /// <summary>
+    /// Emits the <c>storage.throttled</c> event (ID 10310) and records metrics.
+    /// </summary>
+    internal static void StorageThrottled(
+        this ILogger logger,
+        int httpStatusCode,
+        string storageAccountName,
+        long? retryAfterMs,
+        string? currentLimit,
+        Exception? exception = null)
+    {
+        LogStorageThrottled(logger, exception, httpStatusCode, storageAccountName,
+            retryAfterMs, currentLimit);
+
+        ThrottledCount.Add(1,
+            new KeyValuePair<string, object?>("storageAccountName", storageAccountName),
+            new KeyValuePair<string, object?>("httpStatusCode", httpStatusCode));
+    }
+
+    // ─── Classification Helpers ─────────────────────────────────────────
+
+    /// <summary>
+    /// Determines whether a <see cref="RequestFailedException"/> represents
+    /// a connection-level failure (DNS, socket, timeout) rather than an HTTP error.
+    /// </summary>
+    internal static bool IsConnectionError(RequestFailedException ex)
+    {
+        // Connection errors have Status == 0 (no HTTP response received)
+        // and an inner exception indicating a network-level failure.
+        if (ex.Status != 0)
+        {
+            return false;
+        }
+
+        return ex.InnerException is
+            System.Net.Http.HttpRequestException or
+            System.Net.Sockets.SocketException or
+            TaskCanceledException or
+            TimeoutException or
+            IOException;
+    }
+
+    /// <summary>
+    /// Determines whether a <see cref="RequestFailedException"/> represents
+    /// an authentication or authorization failure (HTTP 401 or 403).
+    /// </summary>
+    internal static bool IsAuthError(RequestFailedException ex)
+    {
+        return ex.Status is 401 or 403;
+    }
+
+    /// <summary>
+    /// Determines whether a <see cref="RequestFailedException"/> represents
+    /// a throttling response (HTTP 429 or 503).
+    /// </summary>
+    internal static bool IsThrottlingError(RequestFailedException ex)
+    {
+        return ex.Status is 429 or 503;
+    }
+
+    /// <summary>
+    /// Classifies the failure reason from the inner exception type.
+    /// </summary>
+    internal static string ClassifyFailureReason(RequestFailedException ex)
+    {
+        return ex.InnerException switch
+        {
+            System.Net.Http.HttpRequestException => "HttpRequestException",
+            System.Net.Sockets.SocketException => "SocketException",
+            TaskCanceledException => "Timeout",
+            TimeoutException => "Timeout",
+            IOException => "IOException",
+            _ => "Unknown"
+        };
+    }
+
+    /// <summary>
+    /// Detects the authentication scheme from the HTTP request.
+    /// </summary>
+    internal static string DetectAuthScheme(AzureRequest request)
+    {
+        if (request.Headers.TryGetValue("Authorization", out var authHeader))
+        {
+            if (authHeader.StartsWith("SharedKey", StringComparison.OrdinalIgnoreCase))
+            {
+                return "SharedKey";
+            }
+            if (authHeader.StartsWith("Bearer", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Bearer";
+            }
+            return "Unknown";
+        }
+
+        // Check for SAS token in query string
+        var uri = request.Uri.ToUri();
+        var query = uri.Query;
+        if (query.Contains("sig=", StringComparison.OrdinalIgnoreCase))
+        {
+            return "SAS";
+        }
+
+        return "Anonymous";
+    }
+
+    /// <summary>
+    /// Extracts a privacy-safe identity hint (SHA-256 hash of the account portion)
+    /// from the Authorization header. Returns null if not available.
+    /// </summary>
+    internal static string? ExtractIdentityHint(AzureRequest request)
+    {
+        if (!request.Headers.TryGetValue("Authorization", out var authHeader))
+        {
+            return null;
+        }
+
+        // Extract the account/identity part before hashing
+        var parts = authHeader.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length < 2)
+        {
+            return null;
+        }
+
+        // For "SharedKey account:signature" — hash the account part
+        var credential = parts[1];
+        var colonIndex = credential.IndexOf(':', StringComparison.Ordinal);
+        var identity = colonIndex >= 0 ? credential[..colonIndex] : credential;
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(identity);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexStringLower(hash)[..16]; // First 16 hex chars for brevity
+    }
+
+    /// <summary>
+    /// Parses the Retry-After header value and returns it in milliseconds,
+    /// clamped to a maximum of 300,000 ms (5 minutes).
+    /// Returns null if the header is not present or cannot be parsed.
+    /// </summary>
+    internal static long? ParseRetryAfterMs(RequestFailedException ex)
+    {
+        // RequestFailedException doesn't expose response headers directly.
+        // The Retry-After info is sometimes in the message or headers.
+        // Since we can't access response headers from the exception,
+        // return null — callers can set this from the HttpMessage if available.
+        return null;
+    }
+
+    /// <summary>
+    /// Parses the Retry-After header from the HTTP message response,
+    /// clamped to a maximum of 300,000 ms (5 minutes).
+    /// </summary>
+    internal static long? ParseRetryAfterMs(AzureHttpMessage? message)
+    {
+        const long maxRetryAfterMs = 300_000; // 5 minutes
+
+        if (message is null)
+        {
+            return null;
+        }
+
+        // Response getter throws InvalidOperationException if no response was set
+        // (transport-level failures). Guard with try-catch.
+        string? retryAfter;
+        try
+        {
+            if (message.Response is null)
+            {
+                return null;
+            }
+
+            if (!message.Response.Headers.TryGetValue("Retry-After", out retryAfter))
+            {
+                return null;
+            }
+        }
+#pragma warning disable CA1031 // Response getter may throw when not set
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+#pragma warning restore CA1031
+
+        // Retry-After can be seconds (integer) or an HTTP-date
+        if (long.TryParse(retryAfter, System.Globalization.CultureInfo.InvariantCulture, out var seconds))
+        {
+            var ms = seconds * 1000;
+            return Math.Min(ms, maxRetryAfterMs);
+        }
+
+        // Try parsing as HTTP-date
+        if (DateTimeOffset.TryParse(retryAfter, System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out var date))
+        {
+            var delay = (long)(date - DateTimeOffset.UtcNow).TotalMilliseconds;
+            return Math.Clamp(delay, 0, maxRetryAfterMs);
+        }
+
+        return null;
+    }
+}

--- a/src/OtelEvents.Azure.Storage/OtelEventsAzureStorageOptions.cs
+++ b/src/OtelEvents.Azure.Storage/OtelEventsAzureStorageOptions.cs
@@ -38,4 +38,13 @@ public sealed class OtelEventsAzureStorageOptions
     /// Default: empty.
     /// </summary>
     public IList<string> ExcludeQueues { get; set; } = [];
+
+    /// <summary>
+    /// Enable infrastructure event emission (connection.failed, auth.failed, throttled).
+    /// These events provide deeper diagnostics for Azure Storage failures
+    /// by classifying <c>RequestFailedException</c> into connection, authentication,
+    /// and throttling categories.
+    /// Default: true.
+    /// </summary>
+    public bool EmitInfrastructureEvents { get; set; } = true;
 }

--- a/src/OtelEvents.Azure.Storage/OtelEventsStoragePipelinePolicy.cs
+++ b/src/OtelEvents.Azure.Storage/OtelEventsStoragePipelinePolicy.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Azure;
 using Azure.Core;
 using Azure.Core.Pipeline;
 using Microsoft.Extensions.Logging;
@@ -85,6 +86,12 @@ internal sealed class OtelEventsStoragePipelinePolicy : HttpPipelinePolicy
         var httpMethod = message.Request.Method.Method;
         var operation = StorageOperationClassifier.Classify(requestUri, httpMethod);
 
+        // Infrastructure events can fire even for unclassified operations
+        if (exception is RequestFailedException rfex && _options.EmitInfrastructureEvents)
+        {
+            EmitInfrastructureEvent(message, rfex, requestUri, durationMs);
+        }
+
         if (operation is null)
         {
             return;
@@ -100,7 +107,7 @@ internal sealed class OtelEventsStoragePipelinePolicy : HttpPipelinePolicy
             return;
         }
 
-        var statusCode = message.Response?.Status ?? 0;
+        var statusCode = GetResponseStatus(message);
         var contentLength = GetContentLength(message);
         var isError = exception is not null || statusCode >= 400;
 
@@ -210,6 +217,70 @@ internal sealed class OtelEventsStoragePipelinePolicy : HttpPipelinePolicy
     }
 
     /// <summary>
+    /// Emits infrastructure events (connection.failed, auth.failed, throttled)
+    /// by classifying the <see cref="RequestFailedException"/>.
+    /// These are supplemental — the regular error event is still emitted.
+    /// </summary>
+    private void EmitInfrastructureEvent(
+        HttpMessage message,
+        RequestFailedException rfex,
+        Uri requestUri,
+        double durationMs)
+    {
+        var accountName = ExtractAccountName(requestUri);
+
+        try
+        {
+            if (StorageInfrastructureEvents.IsConnectionError(rfex))
+            {
+                _logger.StorageConnectionFailed(
+                    endpoint: requestUri.Host,
+                    storageAccountName: accountName,
+                    durationMs,
+                    errorType: rfex.GetType().Name,
+                    errorMessage: rfex.Message,
+                    failureReason: StorageInfrastructureEvents.ClassifyFailureReason(rfex),
+                    exception: rfex);
+            }
+            else if (StorageInfrastructureEvents.IsAuthError(rfex))
+            {
+                _logger.StorageAuthFailed(
+                    httpStatusCode: rfex.Status,
+                    storageAccountName: accountName,
+                    authScheme: StorageInfrastructureEvents.DetectAuthScheme(message.Request),
+                    identityHint: StorageInfrastructureEvents.ExtractIdentityHint(message.Request),
+                    exception: rfex);
+            }
+            else if (StorageInfrastructureEvents.IsThrottlingError(rfex))
+            {
+                _logger.StorageThrottled(
+                    httpStatusCode: rfex.Status,
+                    storageAccountName: accountName,
+                    retryAfterMs: StorageInfrastructureEvents.ParseRetryAfterMs(message),
+                    currentLimit: null,
+                    exception: rfex);
+            }
+        }
+#pragma warning disable CA1031 // Defensive: infrastructure event emission must never break the pipeline
+        catch (Exception)
+        {
+            // Observe, never swallow pipeline-critical exceptions
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <summary>
+    /// Extracts the storage account name from the request URI host.
+    /// Returns "unknown" if the host format is not recognized.
+    /// </summary>
+    private static string ExtractAccountName(Uri requestUri)
+    {
+        var host = requestUri.Host;
+        var dotIndex = host.IndexOf('.', StringComparison.Ordinal);
+        return dotIndex > 0 ? host[..dotIndex] : "unknown";
+    }
+
+    /// <summary>
     /// Checks whether events for this operation type are enabled in the options.
     /// </summary>
     private bool IsOperationEnabled(StorageOperationInfo operation)
@@ -258,21 +329,48 @@ internal sealed class OtelEventsStoragePipelinePolicy : HttpPipelinePolicy
     }
 
     /// <summary>
+    /// Extracts the HTTP status code from the response.
+    /// Returns 0 if no response is available (e.g., transport-level failure).
+    /// </summary>
+    private static int GetResponseStatus(HttpMessage message)
+    {
+        try
+        {
+            return message.Response?.Status ?? 0;
+        }
+#pragma warning disable CA1031 // Response getter throws when not set — expected for transport failures
+        catch (InvalidOperationException)
+        {
+            return 0;
+        }
+#pragma warning restore CA1031
+    }
+
+    /// <summary>
     /// Extracts content length from the response headers.
     /// Returns 0 if not available.
     /// </summary>
     private static long GetContentLength(HttpMessage message)
     {
-        if (message.Response is null)
+        try
         {
-            return 0;
-        }
+            if (message.Response is null)
+            {
+                return 0;
+            }
 
-        if (message.Response.Headers.TryGetValue("Content-Length", out var value) &&
-            long.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var length))
-        {
-            return length;
+            if (message.Response.Headers.TryGetValue("Content-Length", out var value) &&
+                long.TryParse(value, System.Globalization.CultureInfo.InvariantCulture, out var length))
+            {
+                return length;
+            }
         }
+#pragma warning disable CA1031 // Response getter throws when not set — expected for transport failures
+        catch (InvalidOperationException)
+        {
+            // No response available
+        }
+#pragma warning restore CA1031
 
         return 0;
     }

--- a/src/OtelEvents.Azure.Storage/Schemas/azure-storage.all.yaml
+++ b/src/OtelEvents.Azure.Storage/Schemas/azure-storage.all.yaml
@@ -53,6 +53,44 @@ fields:
     type: int
     description: "Number of messages received from a queue"
 
+  # ─── Infrastructure Event Fields ─────────────────────────────────────
+
+  endpoint:
+    type: string
+    description: "Storage endpoint hostname"
+
+  errorMessage:
+    type: string
+    description: "Exception message for connection failures"
+
+  failureReason:
+    type: string
+    description: "Classified failure reason (HttpRequestException, SocketException, Timeout, etc.)"
+    index: true
+
+  httpStatusCode:
+    type: int
+    description: "HTTP status code for auth/throttling failures"
+    index: true
+
+  authScheme:
+    type: string
+    description: "Authentication scheme detected (SharedKey, SAS, Bearer, Anonymous, Unknown)"
+    index: true
+
+  identityHint:
+    type: string
+    description: "SHA-256 hash (first 16 hex chars) of the identity portion, for correlation without PII"
+
+  retryAfterMs:
+    type: long
+    description: "Retry-After value in milliseconds, clamped to 300000 (5 min)"
+    unit: "ms"
+
+  currentLimit:
+    type: string
+    description: "Current rate limit information, if available from response headers"
+
 events:
   storage.blob.uploaded:
     id: 10301
@@ -166,3 +204,47 @@ events:
         unit: "errors"
         labels: [storageQueueName, storageStatusCode]
     tags: [storage, queue, error]
+
+  # ─── Infrastructure Events ───────────────────────────────────────────
+
+  storage.connection.failed:
+    id: 10308
+    severity: ERROR
+    exception: true
+    description: "Storage connection failed (DNS, socket, or timeout). No HTTP response received."
+    message: "Storage connection to {endpoint} failed after {durationMs}ms: {failureReason}"
+    fields: [endpoint, storageAccountName, durationMs, errorType, errorMessage, failureReason]
+    metrics:
+      otel.storage.connection.failed.count:
+        type: counter
+        unit: "failures"
+        labels: [storageAccountName]
+    tags: [storage, infrastructure, error]
+
+  storage.auth.failed:
+    id: 10309
+    severity: ERROR
+    exception: true
+    description: "Storage authentication/authorization failed (HTTP 401 or 403)."
+    message: "Storage auth failed for {storageAccountName} with {httpStatusCode} ({authScheme})"
+    fields: [httpStatusCode, storageAccountName, authScheme, identityHint]
+    metrics:
+      otel.storage.auth.failed.count:
+        type: counter
+        unit: "failures"
+        labels: [storageAccountName, authScheme]
+    tags: [storage, infrastructure, auth, error]
+
+  storage.throttled:
+    id: 10310
+    severity: WARN
+    exception: true
+    description: "Storage request was throttled (HTTP 429 or 503)."
+    message: "Storage request to {storageAccountName} was throttled ({httpStatusCode})"
+    fields: [httpStatusCode, storageAccountName, retryAfterMs, currentLimit]
+    metrics:
+      otel.storage.throttled.count:
+        type: counter
+        unit: "events"
+        labels: [storageAccountName, httpStatusCode]
+    tags: [storage, infrastructure, throttle]

--- a/tests/OtelEvents.Azure.Storage.Tests/OtelEventsAzureStorageOptionsTests.cs
+++ b/tests/OtelEvents.Azure.Storage.Tests/OtelEventsAzureStorageOptionsTests.cs
@@ -49,6 +49,14 @@ public sealed class OtelEventsAzureStorageOptionsTests
     }
 
     [Fact]
+    public void DefaultOptions_InfrastructureEventsEnabled()
+    {
+        var options = new OtelEventsAzureStorageOptions();
+
+        Assert.True(options.EmitInfrastructureEvents);
+    }
+
+    [Fact]
     public void Options_CanConfigureAllProperties()
     {
         var options = new OtelEventsAzureStorageOptions
@@ -56,6 +64,7 @@ public sealed class OtelEventsAzureStorageOptionsTests
             EnableBlobEvents = false,
             EnableQueueEvents = false,
             EnableCausalScope = false,
+            EmitInfrastructureEvents = false,
             ExcludeContainers = ["logs", "diagnostics"],
             ExcludeQueues = ["internal-queue"]
         };
@@ -63,6 +72,7 @@ public sealed class OtelEventsAzureStorageOptionsTests
         Assert.False(options.EnableBlobEvents);
         Assert.False(options.EnableQueueEvents);
         Assert.False(options.EnableCausalScope);
+        Assert.False(options.EmitInfrastructureEvents);
         Assert.Equal(2, options.ExcludeContainers.Count);
         Assert.Single(options.ExcludeQueues);
     }

--- a/tests/OtelEvents.Azure.Storage.Tests/StorageInfrastructureEventsTests.cs
+++ b/tests/OtelEvents.Azure.Storage.Tests/StorageInfrastructureEventsTests.cs
@@ -1,0 +1,410 @@
+using Azure;
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace OtelEvents.Azure.Storage.Tests;
+
+/// <summary>
+/// Tests for infrastructure events: storage.connection.failed (10308),
+/// storage.auth.failed (10309), and storage.throttled (10310).
+/// Verifies that RequestFailedException is classified and the correct
+/// infrastructure event is emitted with the expected fields.
+/// </summary>
+public sealed class StorageInfrastructureEventsTests
+{
+    // ─── Test Infrastructure ──────────────────────────────────────────
+
+    private static (HttpPipeline Pipeline, TestLogExporter Exporter, MockPipelineTransport Transport)
+        CreateThrowingPipeline(
+            Func<Request, MockPipelineResponse>? responseFactory = null,
+            Action<OtelEventsAzureStorageOptions>? configureOptions = null)
+    {
+        var exporter = new TestLogExporter();
+
+        var services = new ServiceCollection();
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddOpenTelemetry(otel =>
+            {
+                otel.IncludeFormattedMessage = true;
+                otel.ParseStateValues = true;
+                otel.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+            });
+        });
+
+        var storageOptions = new OtelEventsAzureStorageOptions();
+        storageOptions.EmitInfrastructureEvents = true;
+        configureOptions?.Invoke(storageOptions);
+        services.AddSingleton(storageOptions);
+
+        var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<OtelEvents.Azure.Storage.Events.OtelEventsStorageEventSource>>();
+
+        var policy = new OtelEventsStoragePipelinePolicy(logger, storageOptions);
+
+        var transport = new MockPipelineTransport(responseFactory ?? (_ => new MockPipelineResponse(200)));
+        var clientOptions = new TestClientOptions { Transport = transport };
+        var pipeline = HttpPipelineBuilder.Build(clientOptions, policy);
+
+        return (pipeline, exporter, transport);
+    }
+
+    private static (HttpPipeline Pipeline, TestLogExporter Exporter)
+        CreateExceptionThrowingPipeline(
+            RequestFailedException exceptionToThrow,
+            Action<OtelEventsAzureStorageOptions>? configureOptions = null)
+    {
+        var exporter = new TestLogExporter();
+
+        var services = new ServiceCollection();
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddOpenTelemetry(otel =>
+            {
+                otel.IncludeFormattedMessage = true;
+                otel.ParseStateValues = true;
+                otel.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+            });
+        });
+
+        var storageOptions = new OtelEventsAzureStorageOptions();
+        storageOptions.EmitInfrastructureEvents = true;
+        configureOptions?.Invoke(storageOptions);
+        services.AddSingleton(storageOptions);
+
+        var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<OtelEvents.Azure.Storage.Events.OtelEventsStorageEventSource>>();
+
+        var policy = new OtelEventsStoragePipelinePolicy(logger, storageOptions);
+
+        var transport = new ThrowingMockTransport(exceptionToThrow);
+        var clientOptions = new TestClientOptions { Transport = transport };
+        var pipeline = HttpPipelineBuilder.Build(clientOptions, policy);
+
+        return (pipeline, exporter);
+    }
+
+    private static HttpMessage CreateMessage(HttpPipeline pipeline, string uri, RequestMethod method)
+    {
+        var message = pipeline.CreateMessage();
+        message.Request.Uri.Reset(new Uri(uri));
+        message.Request.Method = method;
+        return message;
+    }
+
+    // ─── storage.connection.failed (10308) ────────────────────────────
+
+    [Fact]
+    public void Process_ConnectionError_EmitsStorageConnectionFailed()
+    {
+        var innerEx = new System.Net.Http.HttpRequestException("Connection refused");
+        var rfex = new RequestFailedException("Unable to connect", innerEx);
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Put);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.connection.failed");
+        var record = exporter.AssertSingle("storage.connection.failed");
+        Assert.Equal(10308, record.EventId.Id);
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+        record.AssertAttribute("storageAccountName", "myaccount");
+        record.AssertHasAttribute("durationMs");
+        record.AssertHasAttribute("errorType");
+        record.AssertHasAttribute("errorMessage");
+        record.AssertHasAttribute("failureReason");
+    }
+
+    [Fact]
+    public void Process_ConnectionError_EndpointField()
+    {
+        var innerEx = new System.Net.Http.HttpRequestException("Name resolution failure");
+        var rfex = new RequestFailedException("DNS lookup failed", innerEx);
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        var record = exporter.AssertSingle("storage.connection.failed");
+        record.AssertAttribute("endpoint", "myaccount.blob.core.windows.net");
+    }
+
+    [Fact]
+    public void Process_TaskCanceledException_EmitsConnectionFailed()
+    {
+        var innerEx = new TaskCanceledException("Request timed out");
+        var rfex = new RequestFailedException("Timeout", innerEx);
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.connection.failed");
+    }
+
+    [Fact]
+    public void Process_SocketException_EmitsConnectionFailed()
+    {
+        var innerEx = new System.Net.Sockets.SocketException(10061); // Connection refused
+        var rfex = new RequestFailedException("Connection failed", innerEx);
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.queue.core.windows.net/tasks/messages",
+            RequestMethod.Post);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.connection.failed");
+        var record = exporter.AssertSingle("storage.connection.failed");
+        record.AssertAttribute("storageAccountName", "myaccount");
+    }
+
+    // ─── storage.auth.failed (10309) ──────────────────────────────────
+
+    [Fact]
+    public void Process_Http401_EmitsStorageAuthFailed()
+    {
+        var rfex = new RequestFailedException(401, "Unauthorized");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/private/secret.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.auth.failed");
+        var record = exporter.AssertSingle("storage.auth.failed");
+        Assert.Equal(10309, record.EventId.Id);
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+        record.AssertAttribute("httpStatusCode", 401);
+        record.AssertAttribute("storageAccountName", "myaccount");
+        record.AssertHasAttribute("authScheme");
+    }
+
+    [Fact]
+    public void Process_Http403_EmitsStorageAuthFailed()
+    {
+        var rfex = new RequestFailedException(403, "Forbidden");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Put);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.auth.failed");
+        var record = exporter.AssertSingle("storage.auth.failed");
+        record.AssertAttribute("httpStatusCode", 403);
+    }
+
+    [Fact]
+    public void Process_AuthFailed_DetectsSharedKeyScheme()
+    {
+        var rfex = new RequestFailedException(403, "SharedKey auth failed");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+        message.Request.Headers.Add("Authorization", "SharedKey myaccount:abc123");
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        var record = exporter.AssertSingle("storage.auth.failed");
+        record.AssertAttribute("authScheme", "SharedKey");
+    }
+
+    [Fact]
+    public void Process_AuthFailed_DetectsSasScheme()
+    {
+        var rfex = new RequestFailedException(403, "SAS token expired");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt?sig=abc&se=2024-01-01",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        var record = exporter.AssertSingle("storage.auth.failed");
+        record.AssertAttribute("authScheme", "SAS");
+    }
+
+    [Fact]
+    public void Process_AuthFailed_NoAuthHeader_ReportsAnonymous()
+    {
+        var rfex = new RequestFailedException(401, "Unauthorized");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+        // No Authorization header, no SAS query params
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        var record = exporter.AssertSingle("storage.auth.failed");
+        record.AssertAttribute("authScheme", "Anonymous");
+    }
+
+    // ─── storage.throttled (10310) ────────────────────────────────────
+
+    [Fact]
+    public void Process_Http429_EmitsStorageThrottled()
+    {
+        var rfex = new RequestFailedException(429, "Too Many Requests");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.throttled");
+        var record = exporter.AssertSingle("storage.throttled");
+        Assert.Equal(10310, record.EventId.Id);
+        Assert.Equal(LogLevel.Warning, record.LogLevel);
+        record.AssertAttribute("httpStatusCode", 429);
+        record.AssertAttribute("storageAccountName", "myaccount");
+    }
+
+    [Fact]
+    public void Process_Http503_EmitsStorageThrottled()
+    {
+        var rfex = new RequestFailedException(503, "Service Unavailable");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.queue.core.windows.net/tasks/messages",
+            RequestMethod.Post);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventEmitted("storage.throttled");
+        var record = exporter.AssertSingle("storage.throttled");
+        record.AssertAttribute("httpStatusCode", 503);
+        record.AssertAttribute("storageAccountName", "myaccount");
+    }
+
+    [Fact]
+    public void Process_Throttled_NoRetryAfterHeader_ReturnsNull()
+    {
+        var rfex = new RequestFailedException(429, "Too Many Requests");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        var record = exporter.AssertSingle("storage.throttled");
+        // retryAfterMs should be null/not present when no Retry-After header
+        // (the field is nullable, so it simply won't be set)
+        record.AssertHasAttribute("retryAfterMs");
+    }
+
+    // ─── Opt-in behavior ──────────────────────────────────────────────
+
+    [Fact]
+    public void Process_InfraEventsDisabled_NoInfraEventEmitted()
+    {
+        var rfex = new RequestFailedException(401, "Unauthorized");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(
+            rfex,
+            configureOptions: o => o.EmitInfrastructureEvents = false);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        exporter.AssertEventNotEmitted("storage.auth.failed");
+        exporter.AssertEventNotEmitted("storage.connection.failed");
+        exporter.AssertEventNotEmitted("storage.throttled");
+        // The regular blob.failed event should still be emitted
+        exporter.AssertEventEmitted("storage.blob.failed");
+    }
+
+    // ─── Supplemental behavior (infra + regular event) ────────────────
+
+    [Fact]
+    public void Process_Http401_EmitsBothAuthFailedAndBlobFailed()
+    {
+        var rfex = new RequestFailedException(401, "Unauthorized");
+        var (pipeline, exporter) = CreateExceptionThrowingPipeline(rfex);
+
+        var message = CreateMessage(pipeline,
+            "https://myaccount.blob.core.windows.net/container/blob.txt",
+            RequestMethod.Get);
+
+        Assert.Throws<RequestFailedException>(() =>
+            pipeline.Send(message, CancellationToken.None));
+
+        // Infrastructure event emitted
+        exporter.AssertEventEmitted("storage.auth.failed");
+        // Regular error event also emitted
+        exporter.AssertEventEmitted("storage.blob.failed");
+    }
+}
+
+/// <summary>
+/// Mock transport that throws a RequestFailedException on every request.
+/// Used to simulate Azure Storage connection and authentication failures.
+/// </summary>
+internal sealed class ThrowingMockTransport : HttpPipelineTransport
+{
+    private readonly RequestFailedException _exception;
+
+    public ThrowingMockTransport(RequestFailedException exception)
+    {
+        _exception = exception;
+    }
+
+    public override Request CreateRequest() => new MockPipelineRequest();
+
+    public override void Process(HttpMessage message)
+    {
+        throw _exception;
+    }
+
+    public override ValueTask ProcessAsync(HttpMessage message)
+    {
+        throw _exception;
+    }
+}


### PR DESCRIPTION
Adds 3 infrastructure events to OtelEvents.Azure.Storage:
- `storage.connection.failed` (10308) — DNS, socket, timeout errors
- `storage.auth.failed` (10309) — 401/403 with auth scheme detection + hashed identity
- `storage.throttled` (10310) — 429/503 with retry-after parsing

15 new tests (62 total). Part of #6.