### PR TITLE
feat(CosmosDb): add connection, auth, throttle infrastructure events (#6)

### DIFF
--- a/src/OtelEvents.Azure.CosmosDb/Events/CosmosDbInfrastructureEvents.cs
+++ b/src/OtelEvents.Azure.CosmosDb/Events/CosmosDbInfrastructureEvents.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
+
+namespace OtelEvents.Azure.CosmosDb.Events;
+
+/// <summary>
+/// Pre-compiled [LoggerMessage] methods and metrics for CosmosDB infrastructure events.
+/// Maps to event IDs 10205–10207 (connection failures, auth failures, throttling).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Infrastructure events are supplemental — they fire <em>in addition to</em> the
+/// existing <c>cosmosdb.query.failed</c> event (10202), not instead of it.
+/// They are gated by <see cref="OtelEventsCosmosDbOptions.EmitInfrastructureEvents"/>
+/// (default: <c>false</c>) so existing consumers see no change unless they opt in.
+/// </para>
+/// <para>
+/// This code is pre-compiled in the NuGet package — consumers do NOT need
+/// OtelEvents.Schema at build time.
+/// </para>
+/// </remarks>
+internal static partial class CosmosDbInfrastructureEvents
+{
+    // ─── Meter & Instruments ────────────────────────────────────────────
+
+    private static readonly Meter s_meter = new("OtelEvents.Azure.CosmosDb", "1.0.0");
+
+    /// <summary>Counter: total CosmosDB connection failures.</summary>
+    internal static readonly Counter<long> ConnectionFailureCount =
+        s_meter.CreateCounter<long>(
+            "otel.cosmosdb.connection.failure.count", "errors",
+            "Total CosmosDB connection failures");
+
+    /// <summary>Counter: total CosmosDB authentication failures.</summary>
+    internal static readonly Counter<long> AuthFailureCount =
+        s_meter.CreateCounter<long>(
+            "otel.cosmosdb.auth.failure.count", "errors",
+            "Total CosmosDB authentication failures");
+
+    /// <summary>Counter: total CosmosDB throttled requests (HTTP 429).</summary>
+    internal static readonly Counter<long> ThrottledCount =
+        s_meter.CreateCounter<long>(
+            "otel.cosmosdb.throttled.count", "requests",
+            "Total CosmosDB throttled requests");
+
+    // ─── Event: cosmosdb.connection.failed (ID 10205) ───────────────────
+
+    [LoggerMessage(
+        EventId = 10205,
+        EventName = "cosmosdb.connection.failed",
+        Level = LogLevel.Error,
+        Message = "CosmosDB connection failed to {endpoint} database={cosmosDatabase} after {durationMs}ms error={errorType} reason={failureReason} message={errorMessage}")]
+    private static partial void LogConnectionFailed(
+        ILogger logger,
+        Exception? exception,
+        string endpoint,
+        string cosmosDatabase,
+        double durationMs,
+        string errorType,
+        string errorMessage,
+        string failureReason);
+
+    /// <summary>
+    /// Emits the <c>cosmosdb.connection.failed</c> event (ID 10205) and records metrics.
+    /// Fires when a CosmosException indicates a connection-level failure.
+    /// </summary>
+    internal static void CosmosDbConnectionFailed(
+        this ILogger logger,
+        string endpoint,
+        string cosmosDatabase,
+        double durationMs,
+        string errorType,
+        string errorMessage,
+        string failureReason,
+        Exception? exception)
+    {
+        LogConnectionFailed(
+            logger, exception, endpoint, cosmosDatabase,
+            durationMs, errorType, errorMessage, failureReason);
+
+        ConnectionFailureCount.Add(1,
+            new KeyValuePair<string, object?>("cosmosDatabase", cosmosDatabase),
+            new KeyValuePair<string, object?>("failureReason", failureReason));
+    }
+
+    // ─── Event: cosmosdb.auth.failed (ID 10206) ─────────────────────────
+
+    [LoggerMessage(
+        EventId = 10206,
+        EventName = "cosmosdb.auth.failed",
+        Level = LogLevel.Error,
+        Message = "CosmosDB auth failed on database={cosmosDatabase} status={httpStatusCode} scheme={authScheme} identity={identityHint}")]
+    private static partial void LogAuthFailed(
+        ILogger logger,
+        Exception? exception,
+        int httpStatusCode,
+        string cosmosDatabase,
+        string authScheme,
+        string identityHint);
+
+    /// <summary>
+    /// Emits the <c>cosmosdb.auth.failed</c> event (ID 10206) and records metrics.
+    /// Fires when a CosmosException has HTTP status 401 or 403.
+    /// </summary>
+    internal static void CosmosDbAuthFailed(
+        this ILogger logger,
+        int httpStatusCode,
+        string cosmosDatabase,
+        string authScheme,
+        string identityHint,
+        Exception? exception)
+    {
+        LogAuthFailed(
+            logger, exception, httpStatusCode, cosmosDatabase,
+            authScheme, identityHint);
+
+        AuthFailureCount.Add(1,
+            new KeyValuePair<string, object?>("cosmosDatabase", cosmosDatabase),
+            new KeyValuePair<string, object?>("httpStatusCode", httpStatusCode));
+    }
+
+    // ─── Event: cosmosdb.throttled (ID 10207) ───────────────────────────
+
+    [LoggerMessage(
+        EventId = 10207,
+        EventName = "cosmosdb.throttled",
+        Level = LogLevel.Warning,
+        Message = "CosmosDB throttled on {cosmosDatabase}/{cosmosContainer} status={httpStatusCode} retryAfter={retryAfterMs}ms charge={cosmosRequestCharge} RU")]
+    private static partial void LogThrottled(
+        ILogger logger,
+        Exception? exception,
+        int httpStatusCode,
+        string cosmosDatabase,
+        string cosmosContainer,
+        double retryAfterMs,
+        double cosmosRequestCharge);
+
+    /// <summary>
+    /// Emits the <c>cosmosdb.throttled</c> event (ID 10207) and records metrics.
+    /// Fires when a CosmosException has HTTP status 429 (Request Rate Too Large).
+    /// </summary>
+    internal static void CosmosDbThrottled(
+        this ILogger logger,
+        int httpStatusCode,
+        string cosmosDatabase,
+        string cosmosContainer,
+        double retryAfterMs,
+        double cosmosRequestCharge,
+        Exception? exception)
+    {
+        LogThrottled(
+            logger, exception, httpStatusCode, cosmosDatabase,
+            cosmosContainer, retryAfterMs, cosmosRequestCharge);
+
+        ThrottledCount.Add(1,
+            new KeyValuePair<string, object?>("cosmosDatabase", cosmosDatabase),
+            new KeyValuePair<string, object?>("cosmosContainer", cosmosContainer));
+    }
+}

--- a/src/OtelEvents.Azure.CosmosDb/OtelEventsCosmosDbObserver.cs
+++ b/src/OtelEvents.Azure.CosmosDb/OtelEventsCosmosDbObserver.cs
@@ -210,6 +210,8 @@ public sealed class OtelEventsCosmosDbObserver :
     /// <summary>
     /// Processes a failed CosmosDB operation event.
     /// All failures emit <c>cosmosdb.query.failed</c> regardless of operation type.
+    /// When <see cref="OtelEventsCosmosDbOptions.EmitInfrastructureEvents"/> is enabled,
+    /// supplemental infrastructure events are emitted based on the HTTP status code.
     /// </summary>
     private void ProcessOperationFailed(object? payload)
     {
@@ -228,6 +230,7 @@ public sealed class OtelEventsCosmosDbObserver :
         var partitionKey = ReadProperty<string>(payload, "PartitionKey");
         var exception = ReadProperty<Exception>(payload, "Exception");
 
+        // Always emit the standard query.failed event (backward-compatible)
         _logger.CosmosDbQueryFailed(
             cosmosDatabase: database,
             cosmosContainer: container,
@@ -238,6 +241,133 @@ public sealed class OtelEventsCosmosDbObserver :
             errorType: errorType,
             cosmosPartitionKey: partitionKey,
             exception: exception);
+
+        // Supplemental infrastructure events — gated by option
+        if (!_options.EmitInfrastructureEvents)
+        {
+            return;
+        }
+
+        EmitInfrastructureEvent(
+            payload, database, container, statusCode,
+            requestCharge, durationMs, errorType, exception);
+    }
+
+    /// <summary>
+    /// Classifies the failure by HTTP status code and emits the appropriate
+    /// infrastructure event (connection, auth, or throttled).
+    /// </summary>
+    private void EmitInfrastructureEvent(
+        object payload,
+        string database,
+        string container,
+        int statusCode,
+        double requestCharge,
+        double durationMs,
+        string errorType,
+        Exception? exception)
+    {
+        switch (statusCode)
+        {
+            case 401 or 403:
+                EmitAuthFailed(payload, database, statusCode, exception);
+                break;
+
+            case 429:
+                EmitThrottled(payload, database, container, statusCode, requestCharge, exception);
+                break;
+
+            default:
+                EmitConnectionFailed(payload, database, durationMs, errorType, exception);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Emits a <c>cosmosdb.connection.failed</c> event for connection-level errors
+    /// (any status code not classified as auth or throttle).
+    /// </summary>
+    private void EmitConnectionFailed(
+        object payload,
+        string database,
+        double durationMs,
+        string errorType,
+        Exception? exception)
+    {
+        var endpoint = ReadProperty<string>(payload, "Endpoint") ?? "unknown";
+        var errorMessage = exception?.Message ?? "Unknown error";
+        var failureReason = ReadProperty<string>(payload, "FailureReason") ?? "ConnectionError";
+
+        _logger.CosmosDbConnectionFailed(
+            endpoint: endpoint,
+            cosmosDatabase: database,
+            durationMs: durationMs,
+            errorType: errorType,
+            errorMessage: errorMessage,
+            failureReason: failureReason,
+            exception: exception);
+    }
+
+    /// <summary>
+    /// Emits a <c>cosmosdb.auth.failed</c> event for HTTP 401/403 responses.
+    /// The identity hint is a SHA-256 hash prefix of the error message to aid
+    /// correlation without leaking credentials.
+    /// </summary>
+    private void EmitAuthFailed(
+        object payload,
+        string database,
+        int statusCode,
+        Exception? exception)
+    {
+        var authScheme = ReadProperty<string>(payload, "AuthScheme") ?? "unknown";
+        var rawIdentity = ReadProperty<string>(payload, "IdentitySource") ?? exception?.Message ?? "";
+        var identityHint = ComputeIdentityHint(rawIdentity);
+
+        _logger.CosmosDbAuthFailed(
+            httpStatusCode: statusCode,
+            cosmosDatabase: database,
+            authScheme: authScheme,
+            identityHint: identityHint,
+            exception: exception);
+    }
+
+    /// <summary>
+    /// Emits a <c>cosmosdb.throttled</c> event for HTTP 429 responses.
+    /// Extracts RetryAfter from the payload (in milliseconds).
+    /// </summary>
+    private void EmitThrottled(
+        object payload,
+        string database,
+        string container,
+        int statusCode,
+        double requestCharge,
+        Exception? exception)
+    {
+        var retryAfterMs = ReadProperty<double>(payload, "RetryAfterMs");
+
+        _logger.CosmosDbThrottled(
+            httpStatusCode: statusCode,
+            cosmosDatabase: database,
+            cosmosContainer: container,
+            retryAfterMs: retryAfterMs,
+            cosmosRequestCharge: requestCharge,
+            exception: exception);
+    }
+
+    /// <summary>
+    /// Computes a SHA-256 hash prefix (first 8 hex chars) of the raw identity
+    /// string for safe logging. Never logs raw credentials or identity values.
+    /// </summary>
+    private static string ComputeIdentityHint(string rawIdentity)
+    {
+        if (string.IsNullOrEmpty(rawIdentity))
+        {
+            return "unknown";
+        }
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes(rawIdentity);
+        var hash = System.Security.Cryptography.SHA256.HashData(bytes);
+        return Convert.ToHexString(hash)[..8].ToUpperInvariant();
     }
 
     // ─── Event emission helpers ─────────────────────────────────────────

--- a/src/OtelEvents.Azure.CosmosDb/OtelEventsCosmosDbOptions.cs
+++ b/src/OtelEvents.Azure.CosmosDb/OtelEventsCosmosDbOptions.cs
@@ -56,4 +56,14 @@ public sealed class OtelEventsCosmosDbOptions
     /// Default: <c>0</c> — emit for all operations.
     /// </summary>
     public double LatencyThresholdMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to emit infrastructure events
+    /// (<c>cosmosdb.connection.failed</c>, <c>cosmosdb.auth.failed</c>,
+    /// <c>cosmosdb.throttled</c>) in addition to the standard operation events.
+    /// Infrastructure events fire supplementally — the existing
+    /// <c>cosmosdb.query.failed</c> event still fires for all failures.
+    /// Default: <c>false</c> — opt-in only (backward-compatible).
+    /// </summary>
+    public bool EmitInfrastructureEvents { get; set; }
 }

--- a/src/OtelEvents.Azure.CosmosDb/Schemas/cosmosdb.all.yaml
+++ b/src/OtelEvents.Azure.CosmosDb/Schemas/cosmosdb.all.yaml
@@ -172,3 +172,92 @@ events:
         description: "CosmosDB point operation RU consumption"
         buckets: [1, 2, 5, 10, 25, 50, 100]
     tags: [cosmosdb, point]
+
+  cosmosdb.connection.failed:
+    id: 10205
+    severity: ERROR
+    description: "A CosmosDB connection-level error occurred (non-auth, non-throttle failures)."
+    message: "CosmosDB connection failed to {endpoint} database={cosmosDatabase} after {durationMs}ms error={errorType}"
+    exception: true
+    supplemental: true
+    fields:
+      endpoint:
+        type: string
+        description: "CosmosDB account endpoint URL"
+        required: true
+      cosmosDatabase: { ref: cosmosDatabase, required: true }
+      durationMs: { ref: durationMs, required: true }
+      errorType: { ref: errorType, required: true }
+      errorMessage:
+        type: string
+        description: "Exception message describing the failure"
+        required: true
+      failureReason:
+        type: string
+        description: "Classified failure reason (e.g., ConnectionError, Timeout)"
+        required: true
+    metrics:
+      otel.cosmosdb.connection.failure.count:
+        type: counter
+        unit: "errors"
+        description: "Total CosmosDB connection failures"
+        labels: [cosmosDatabase, failureReason]
+    tags: [cosmosdb, infrastructure, connection]
+
+  cosmosdb.auth.failed:
+    id: 10206
+    severity: ERROR
+    description: "A CosmosDB authentication or authorization failure occurred (HTTP 401/403)."
+    message: "CosmosDB auth failed on database={cosmosDatabase} status={httpStatusCode} scheme={authScheme}"
+    exception: true
+    supplemental: true
+    fields:
+      httpStatusCode:
+        type: int
+        description: "HTTP status code (401 or 403)"
+        required: true
+      cosmosDatabase: { ref: cosmosDatabase, required: true }
+      authScheme:
+        type: string
+        description: "Authentication scheme used (e.g., MasterKey, AAD)"
+        required: true
+      identityHint:
+        type: string
+        description: "SHA-256 hash prefix (8 chars) of identity source for correlation"
+        sensitivity: internal
+        required: true
+    metrics:
+      otel.cosmosdb.auth.failure.count:
+        type: counter
+        unit: "errors"
+        description: "Total CosmosDB authentication failures"
+        labels: [cosmosDatabase, httpStatusCode]
+    tags: [cosmosdb, infrastructure, auth]
+
+  cosmosdb.throttled:
+    id: 10207
+    severity: WARN
+    description: "A CosmosDB request was throttled (HTTP 429 — Request Rate Too Large)."
+    message: "CosmosDB throttled on {cosmosDatabase}/{cosmosContainer} retryAfter={retryAfterMs}ms charge={cosmosRequestCharge} RU"
+    exception: true
+    supplemental: true
+    fields:
+      httpStatusCode:
+        type: int
+        description: "HTTP status code (429)"
+        required: true
+      cosmosDatabase: { ref: cosmosDatabase, required: true }
+      cosmosContainer: { ref: cosmosContainer, required: true }
+      retryAfterMs:
+        type: double
+        description: "Retry-after delay from CosmosDB response (milliseconds)"
+        unit: "ms"
+        required: true
+      cosmosRequestCharge: { ref: cosmosRequestCharge, required: true }
+    metrics:
+      otel.cosmosdb.throttled.count:
+        type: counter
+        unit: "requests"
+        description: "Total CosmosDB throttled requests"
+        labels: [cosmosDatabase, cosmosContainer]
+    tags: [cosmosdb, infrastructure, throttle]

--- a/tests/OtelEvents.Azure.CosmosDb.Tests/CosmosDbInfrastructureEventsTests.cs
+++ b/tests/OtelEvents.Azure.CosmosDb.Tests/CosmosDbInfrastructureEventsTests.cs
@@ -1,0 +1,418 @@
+using System.Diagnostics;
+using OtelEvents.Azure.CosmosDb.Events;
+
+namespace OtelEvents.Azure.CosmosDb.Tests;
+
+/// <summary>
+/// Tests for CosmosDB infrastructure events (10205–10207): connection failures,
+/// auth failures, and throttling. Verifies the supplemental event model where
+/// infrastructure events fire <em>in addition to</em> the existing query.failed event.
+/// </summary>
+public sealed class CosmosDbInfrastructureEventsTests : IDisposable
+{
+    private readonly TestLogger<OtelEventsCosmosDbEventSource> _logger;
+    private readonly OtelEventsCosmosDbOptions _infraOptions;
+
+    public CosmosDbInfrastructureEventsTests()
+    {
+        _logger = new TestLogger<OtelEventsCosmosDbEventSource>();
+        _infraOptions = new OtelEventsCosmosDbOptions { EmitInfrastructureEvents = true };
+    }
+
+    private OtelEventsCosmosDbObserver CreateObserver(OtelEventsCosmosDbOptions? options = null)
+        => new(_logger, options ?? _infraOptions);
+
+    public void Dispose()
+    {
+        // No-op — observers created per test don't subscribe to global listeners
+    }
+
+    // ─── cosmosdb.connection.failed (10205) ─────────────────────────
+
+    [Fact]
+    public void ConnectionFailed_EmitsCorrectEventId_10205()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateConnectionFailedPayload();
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.connection.failed").Single();
+        Assert.Equal(10205, entry.EventId.Id);
+        Assert.Equal("cosmosdb.connection.failed", entry.EventId.Name);
+    }
+
+    [Fact]
+    public void ConnectionFailed_HasErrorSeverity()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateConnectionFailedPayload();
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.connection.failed").Single();
+        Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Error, entry.LogLevel);
+    }
+
+    [Fact]
+    public void ConnectionFailed_IncludesEndpoint()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateConnectionFailedPayload(endpoint: "https://myaccount.documents.azure.com:443/");
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.connection.failed").Single();
+        Assert.Equal("https://myaccount.documents.azure.com:443/", entry.Parameters["endpoint"]);
+    }
+
+    [Fact]
+    public void ConnectionFailed_IncludesDatabaseAndDuration()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateConnectionFailedPayload(database: "OrderDb", durationMs: 5032.1);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.connection.failed").Single();
+        Assert.Equal("OrderDb", entry.Parameters["cosmosDatabase"]);
+        Assert.Equal(5032.1, entry.Parameters["durationMs"]);
+    }
+
+    [Fact]
+    public void ConnectionFailed_IncludesErrorTypeAndMessage()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var exception = new InvalidOperationException("Connection refused by remote host");
+        var payload = CreateConnectionFailedPayload(
+            errorType: "System.Net.Http.HttpRequestException",
+            failureReason: "ConnectionRefused",
+            exception: exception);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.connection.failed").Single();
+        Assert.Equal("System.Net.Http.HttpRequestException", entry.Parameters["errorType"]);
+        Assert.Equal("Connection refused by remote host", entry.Parameters["errorMessage"]);
+        Assert.Equal("ConnectionRefused", entry.Parameters["failureReason"]);
+    }
+
+    // ─── cosmosdb.auth.failed (10206) ───────────────────────────────
+
+    [Fact]
+    public void AuthFailed_EmitsCorrectEventId_10206()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateAuthFailedPayload(statusCode: 401);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.auth.failed").Single();
+        Assert.Equal(10206, entry.EventId.Id);
+        Assert.Equal("cosmosdb.auth.failed", entry.EventId.Name);
+    }
+
+    [Fact]
+    public void AuthFailed_HasErrorSeverity()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateAuthFailedPayload(statusCode: 401);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.auth.failed").Single();
+        Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Error, entry.LogLevel);
+    }
+
+    [Fact]
+    public void AuthFailed_EmitsForStatus401()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateAuthFailedPayload(statusCode: 401);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.auth.failed").Single();
+        Assert.Equal(401, entry.Parameters["httpStatusCode"]);
+    }
+
+    [Fact]
+    public void AuthFailed_EmitsForStatus403()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateAuthFailedPayload(statusCode: 403);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.auth.failed").Single();
+        Assert.Equal(403, entry.Parameters["httpStatusCode"]);
+    }
+
+    [Fact]
+    public void AuthFailed_IncludesIdentityHint_SHA256Hash()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var exception = new InvalidOperationException("The input authorization token can't serve the request");
+        var payload = CreateAuthFailedPayload(
+            statusCode: 401,
+            identitySource: "master-key-abc",
+            exception: exception);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert — identityHint should be a deterministic 8-char uppercase hex hash
+        var entry = _logger.GetEntriesByEventName("cosmosdb.auth.failed").Single();
+        var identityHint = (string?)entry.Parameters["identityHint"];
+        Assert.NotNull(identityHint);
+        Assert.Equal(8, identityHint.Length);
+        Assert.Matches("^[0-9A-F]{8}$", identityHint);
+
+        // Same input should produce same hash (deterministic)
+        FireExceptionEvent(observer, CreateAuthFailedPayload(
+            statusCode: 401, identitySource: "master-key-abc", exception: exception));
+        var entries = _logger.GetEntriesByEventName("cosmosdb.auth.failed");
+        var entry2 = entries[entries.Count - 1];
+        Assert.Equal(identityHint, entry2.Parameters["identityHint"]);
+    }
+
+    // ─── cosmosdb.throttled (10207) ─────────────────────────────────
+
+    [Fact]
+    public void Throttled_EmitsCorrectEventId_10207()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateThrottledPayload();
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.throttled").Single();
+        Assert.Equal(10207, entry.EventId.Id);
+        Assert.Equal("cosmosdb.throttled", entry.EventId.Name);
+    }
+
+    [Fact]
+    public void Throttled_HasWarnSeverity()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateThrottledPayload();
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.throttled").Single();
+        Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Warning, entry.LogLevel);
+    }
+
+    [Fact]
+    public void Throttled_IncludesRetryAfterMs()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateThrottledPayload(retryAfterMs: 1234.0);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.throttled").Single();
+        Assert.Equal(1234.0, entry.Parameters["retryAfterMs"]);
+    }
+
+    [Fact]
+    public void Throttled_IncludesRequestCharge()
+    {
+        // Arrange
+        var observer = CreateObserver();
+        var payload = CreateThrottledPayload(requestCharge: 99.9);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert
+        var entry = _logger.GetEntriesByEventName("cosmosdb.throttled").Single();
+        Assert.Equal(99.9, entry.Parameters["cosmosRequestCharge"]);
+    }
+
+    // ─── Options & gating tests ─────────────────────────────────────
+
+    [Fact]
+    public void EmitInfrastructureEvents_DefaultsFalse()
+    {
+        // Arrange & Act
+        var options = new OtelEventsCosmosDbOptions();
+
+        // Assert — backward-compatible default
+        Assert.False(options.EmitInfrastructureEvents);
+    }
+
+    [Fact]
+    public void InfraEvents_NotEmitted_WhenDisabled()
+    {
+        // Arrange — EmitInfrastructureEvents = false (default)
+        var options = new OtelEventsCosmosDbOptions();
+        var observer = CreateObserver(options);
+
+        // Act — fire a 429 (throttle) failure
+        FireExceptionEvent(observer, CreateThrottledPayload());
+
+        // Assert — query.failed should fire, but NOT the infra event
+        Assert.Single(_logger.GetEntriesByEventName("cosmosdb.query.failed"));
+        Assert.Empty(_logger.GetEntriesByEventName("cosmosdb.throttled"));
+    }
+
+    [Fact]
+    public void InfraEvents_Emitted_WhenEnabled()
+    {
+        // Arrange — EmitInfrastructureEvents = true
+        var observer = CreateObserver(); // uses _infraOptions with EmitInfrastructureEvents = true
+
+        // Act — fire a 429 (throttle) failure
+        FireExceptionEvent(observer, CreateThrottledPayload());
+
+        // Assert — BOTH events should fire (supplemental model)
+        Assert.Single(_logger.GetEntriesByEventName("cosmosdb.query.failed"));
+        Assert.Single(_logger.GetEntriesByEventName("cosmosdb.throttled"));
+    }
+
+    [Fact]
+    public void NonInfraFailure_StillEmitsQueryFailed_WhenInfraEnabled()
+    {
+        // Arrange — a 500 status code is a connection error in infra classification
+        var observer = CreateObserver();
+        var payload = CreateConnectionFailedPayload(statusCode: 500);
+
+        // Act
+        FireExceptionEvent(observer, payload);
+
+        // Assert — both query.failed and connection.failed should fire
+        Assert.Single(_logger.GetEntriesByEventName("cosmosdb.query.failed"));
+        Assert.Single(_logger.GetEntriesByEventName("cosmosdb.connection.failed"));
+    }
+
+    // ─── Helper methods ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Fires an "Exception" event (failed operation) through the observer.
+    /// </summary>
+    private static void FireExceptionEvent(OtelEventsCosmosDbObserver observer, object? payload)
+    {
+        ((IObserver<KeyValuePair<string, object?>>)observer).OnNext(
+            new KeyValuePair<string, object?>("Azure.Cosmos.Operation.Exception", payload));
+    }
+
+    /// <summary>
+    /// Creates an anonymous payload for a connection-level failure
+    /// (non-auth, non-throttle — defaults to status 503).
+    /// </summary>
+    private static object CreateConnectionFailedPayload(
+        string database = "TestDb",
+        string container = "TestContainer",
+        int statusCode = 503,
+        double durationMs = 5032.1,
+        string errorType = "CosmosException",
+        string? endpoint = "https://test.documents.azure.com:443/",
+        string failureReason = "ConnectionError",
+        Exception? exception = null)
+    {
+        return new
+        {
+            DatabaseName = database,
+            ContainerName = container,
+            RequestCharge = 0.0,
+            DurationMs = durationMs,
+            StatusCode = statusCode,
+            SubStatusCode = 0,
+            ErrorType = errorType,
+            PartitionKey = (string?)null,
+            Exception = exception ?? new InvalidOperationException("Service unavailable"),
+            Endpoint = endpoint,
+            FailureReason = failureReason,
+        };
+    }
+
+    /// <summary>
+    /// Creates an anonymous payload for an auth failure (HTTP 401 or 403).
+    /// </summary>
+    private static object CreateAuthFailedPayload(
+        string database = "TestDb",
+        string container = "TestContainer",
+        int statusCode = 401,
+        string authScheme = "MasterKey",
+        string? identitySource = null,
+        Exception? exception = null)
+    {
+        return new
+        {
+            DatabaseName = database,
+            ContainerName = container,
+            RequestCharge = 0.0,
+            DurationMs = 12.3,
+            StatusCode = statusCode,
+            SubStatusCode = 0,
+            ErrorType = "CosmosException",
+            PartitionKey = (string?)null,
+            Exception = exception ?? new InvalidOperationException("Unauthorized"),
+            AuthScheme = authScheme,
+            IdentitySource = identitySource ?? "default-key",
+        };
+    }
+
+    /// <summary>
+    /// Creates an anonymous payload for a throttled request (HTTP 429).
+    /// </summary>
+    private static object CreateThrottledPayload(
+        string database = "TestDb",
+        string container = "TestContainer",
+        double requestCharge = 99.9,
+        double retryAfterMs = 1234.0,
+        Exception? exception = null)
+    {
+        return new
+        {
+            DatabaseName = database,
+            ContainerName = container,
+            RequestCharge = requestCharge,
+            DurationMs = 50.0,
+            StatusCode = 429,
+            SubStatusCode = 3200,
+            ErrorType = "CosmosException",
+            PartitionKey = (string?)null,
+            Exception = exception ?? new InvalidOperationException("Request rate is large"),
+            RetryAfterMs = retryAfterMs,
+        };
+    }
+}

--- a/tests/OtelEvents.Azure.CosmosDb.Tests/OtelEventsCosmosDbOptionsTests.cs
+++ b/tests/OtelEvents.Azure.CosmosDb.Tests/OtelEventsCosmosDbOptionsTests.cs
@@ -53,6 +53,7 @@ public sealed class OtelEventsCosmosDbOptionsTests
             CaptureRegion = false,
             RuThreshold = 10.0,
             LatencyThresholdMs = 100.0,
+            EmitInfrastructureEvents = true,
         };
 
         Assert.True(options.CaptureQueryText);
@@ -60,5 +61,13 @@ public sealed class OtelEventsCosmosDbOptionsTests
         Assert.False(options.CaptureRegion);
         Assert.Equal(10.0, options.RuThreshold);
         Assert.Equal(100.0, options.LatencyThresholdMs);
+        Assert.True(options.EmitInfrastructureEvents);
+    }
+
+    [Fact]
+    public void Defaults_EmitInfrastructureEvents_IsFalse()
+    {
+        var options = new OtelEventsCosmosDbOptions();
+        Assert.False(options.EmitInfrastructureEvents);
     }
 }


### PR DESCRIPTION
Adds 3 infrastructure events to OtelEvents.Azure.CosmosDb:
- `cosmosdb.connection.failed` (10205)
- `cosmosdb.auth.failed` (10206) — 401/403 with SHA-256 identity hint
- `cosmosdb.throttled` (10207) — 429 RU exhaustion with retryAfterMs
19 new tests. Part of #6.