### PR TITLE
feat(Grpc): add connection, auth, throttle infrastructure events (#6)

### DIFF
--- a/src/OtelEvents.Grpc/Events/GrpcInfrastructureEvents.cs
+++ b/src/OtelEvents.Grpc/Events/GrpcInfrastructureEvents.cs
@@ -1,0 +1,316 @@
+using System.Diagnostics.Metrics;
+using System.Security.Cryptography;
+using System.Text;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+
+namespace OtelEvents.Grpc.Events;
+
+/// <summary>
+/// Pre-compiled [LoggerMessage] methods and metrics for gRPC infrastructure events.
+/// Maps to the grpc.all.yaml schema (event IDs 10104–10106).
+/// These events are supplemental — they fire alongside <c>grpc.call.failed</c> (10103)
+/// to provide domain-specific detail about connection, authentication, and throttling failures.
+/// </summary>
+/// <remarks>
+/// Infrastructure events are opt-in via <see cref="OtelEventsGrpcOptions.EmitInfrastructureEvents"/>
+/// (default: true). They are always wrapped in a defensive try-catch so they never
+/// interfere with the main call lifecycle.
+/// </remarks>
+internal static partial class GrpcInfrastructureEvents
+{
+    // ─── Meter & Instruments ────────────────────────────────────────────
+
+    private static readonly Meter s_meter = new("OtelEvents.Grpc", "1.0.0");
+
+    /// <summary>Counter: gRPC connection failures (StatusCode.Unavailable).</summary>
+    internal static readonly Counter<long> ConnectionFailedCount =
+        s_meter.CreateCounter<long>(
+            "otel.grpc.connection.failed.count", "errors", "gRPC connection failures");
+
+    /// <summary>Counter: gRPC authentication/authorization failures.</summary>
+    internal static readonly Counter<long> AuthFailedCount =
+        s_meter.CreateCounter<long>(
+            "otel.grpc.auth.failed.count", "errors", "gRPC authentication failures");
+
+    /// <summary>Counter: gRPC throttled requests (StatusCode.ResourceExhausted).</summary>
+    internal static readonly Counter<long> ThrottledCount =
+        s_meter.CreateCounter<long>(
+            "otel.grpc.throttled.count", "errors", "gRPC throttled requests");
+
+    // ─── Event: grpc.connection.failed (ID 10104) ───────────────────────
+
+    [LoggerMessage(
+        EventId = 10104,
+        EventName = "grpc.connection.failed",
+        Level = LogLevel.Error,
+        Message = "gRPC {GrpcSide} connection to {GrpcService}/{GrpcMethod} failed: {FailureReason}")]
+    private static partial void LogGrpcConnectionFailed(
+        ILogger logger,
+        Exception exception,
+        string grpcService,
+        string grpcMethod,
+        string grpcSide,
+        string? endpoint,
+        double durationMs,
+        string errorType,
+        string? errorMessage,
+        string? failureReason);
+
+    /// <summary>
+    /// Emits the <c>grpc.connection.failed</c> event (ID 10104) and records metrics.
+    /// Triggered when an RpcException has StatusCode.Unavailable.
+    /// </summary>
+    internal static void GrpcConnectionFailed(
+        this ILogger logger,
+        string grpcService,
+        string grpcMethod,
+        string grpcSide,
+        string? endpoint,
+        double durationMs,
+        string errorType,
+        string? errorMessage,
+        string? failureReason,
+        Exception exception)
+    {
+        LogGrpcConnectionFailed(logger, exception, grpcService, grpcMethod, grpcSide,
+            endpoint, durationMs, errorType, errorMessage, failureReason);
+
+        ConnectionFailedCount.Add(1,
+            new KeyValuePair<string, object?>("grpcService", grpcService),
+            new KeyValuePair<string, object?>("grpcMethod", grpcMethod),
+            new KeyValuePair<string, object?>("grpcSide", grpcSide));
+    }
+
+    // ─── Event: grpc.auth.failed (ID 10105) ─────────────────────────────
+
+    [LoggerMessage(
+        EventId = 10105,
+        EventName = "grpc.auth.failed",
+        Level = LogLevel.Error,
+        Message = "gRPC {GrpcSide} auth failed for {GrpcService}/{GrpcMethod} with HTTP {HttpStatusCode}")]
+    private static partial void LogGrpcAuthFailed(
+        ILogger logger,
+        Exception exception,
+        string grpcService,
+        string grpcMethod,
+        string grpcSide,
+        int httpStatusCode,
+        string? authScheme,
+        string? identityHint);
+
+    /// <summary>
+    /// Emits the <c>grpc.auth.failed</c> event (ID 10105) and records metrics.
+    /// Triggered when an RpcException has StatusCode.Unauthenticated or PermissionDenied.
+    /// Maps gRPC codes to HTTP: Unauthenticated → 401, PermissionDenied → 403.
+    /// </summary>
+    internal static void GrpcAuthFailed(
+        this ILogger logger,
+        string grpcService,
+        string grpcMethod,
+        string grpcSide,
+        int httpStatusCode,
+        string? authScheme,
+        string? identityHint,
+        Exception exception)
+    {
+        LogGrpcAuthFailed(logger, exception, grpcService, grpcMethod, grpcSide,
+            httpStatusCode, authScheme, identityHint);
+
+        AuthFailedCount.Add(1,
+            new KeyValuePair<string, object?>("grpcService", grpcService),
+            new KeyValuePair<string, object?>("grpcMethod", grpcMethod),
+            new KeyValuePair<string, object?>("grpcSide", grpcSide),
+            new KeyValuePair<string, object?>("httpStatusCode", httpStatusCode));
+    }
+
+    // ─── Event: grpc.throttled (ID 10106) ───────────────────────────────
+
+    [LoggerMessage(
+        EventId = 10106,
+        EventName = "grpc.throttled",
+        Level = LogLevel.Warning,
+        Message = "gRPC {GrpcSide} {GrpcService}/{GrpcMethod} throttled")]
+    private static partial void LogGrpcThrottled(
+        ILogger logger,
+        Exception exception,
+        string grpcService,
+        string grpcMethod,
+        string grpcSide,
+        long? retryAfterMs);
+
+    /// <summary>
+    /// Emits the <c>grpc.throttled</c> event (ID 10106) and records metrics.
+    /// Triggered when an RpcException has StatusCode.ResourceExhausted.
+    /// </summary>
+    internal static void GrpcThrottled(
+        this ILogger logger,
+        string grpcService,
+        string grpcMethod,
+        string grpcSide,
+        long? retryAfterMs,
+        Exception exception)
+    {
+        LogGrpcThrottled(logger, exception, grpcService, grpcMethod, grpcSide, retryAfterMs);
+
+        ThrottledCount.Add(1,
+            new KeyValuePair<string, object?>("grpcService", grpcService),
+            new KeyValuePair<string, object?>("grpcMethod", grpcMethod),
+            new KeyValuePair<string, object?>("grpcSide", grpcSide));
+    }
+
+    // ─── Infrastructure Event Classification ────────────────────────────
+
+    /// <summary>
+    /// Classifies an RpcException by StatusCode and emits the appropriate
+    /// infrastructure event. Wrapped in defensive try-catch — never throws.
+    /// </summary>
+    /// <param name="logger">The logger to emit events through.</param>
+    /// <param name="options">Options controlling whether infra events are enabled.</param>
+    /// <param name="serviceName">The gRPC service name.</param>
+    /// <param name="methodName">The gRPC method name.</param>
+    /// <param name="grpcSide">Whether this is "Client" or "Server".</param>
+    /// <param name="ex">The RpcException to classify.</param>
+    /// <param name="durationMs">Call duration in milliseconds.</param>
+    /// <param name="endpoint">The endpoint involved (host for client, peer for server).</param>
+    /// <param name="requestMetadata">Request metadata for auth info extraction.</param>
+    internal static void TryEmitInfrastructureEvent(
+        ILogger logger,
+        OtelEventsGrpcOptions options,
+        string serviceName,
+        string methodName,
+        string grpcSide,
+        RpcException ex,
+        double durationMs,
+        string? endpoint,
+        Metadata? requestMetadata)
+    {
+        if (!options.EmitInfrastructureEvents)
+        {
+            return;
+        }
+
+        try
+        {
+            switch (ex.StatusCode)
+            {
+                case StatusCode.Unavailable:
+                    logger.GrpcConnectionFailed(
+                        grpcService: serviceName,
+                        grpcMethod: methodName,
+                        grpcSide: grpcSide,
+                        endpoint: endpoint,
+                        durationMs: durationMs,
+                        errorType: ex.GetType().Name,
+                        errorMessage: ex.Message,
+                        failureReason: ex.Status.Detail,
+                        exception: ex);
+                    break;
+
+                case StatusCode.Unauthenticated:
+                case StatusCode.PermissionDenied:
+                    var httpStatusCode = ex.StatusCode == StatusCode.Unauthenticated ? 401 : 403;
+                    var (authScheme, identityHint) = ExtractAuthInfo(requestMetadata);
+                    logger.GrpcAuthFailed(
+                        grpcService: serviceName,
+                        grpcMethod: methodName,
+                        grpcSide: grpcSide,
+                        httpStatusCode: httpStatusCode,
+                        authScheme: authScheme,
+                        identityHint: identityHint,
+                        exception: ex);
+                    break;
+
+                case StatusCode.ResourceExhausted:
+                    var retryAfterMs = ExtractRetryAfterMs(ex.Trailers);
+                    logger.GrpcThrottled(
+                        grpcService: serviceName,
+                        grpcMethod: methodName,
+                        grpcSide: grpcSide,
+                        retryAfterMs: retryAfterMs,
+                        exception: ex);
+                    break;
+            }
+        }
+#pragma warning disable CA1031 // Defensive: infrastructure events are supplemental — never interfere with call handling
+        catch
+        {
+            // Intentionally empty — infrastructure event failure must not affect the gRPC call.
+        }
+#pragma warning restore CA1031
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Extracts retry-after-ms from gRPC trailing metadata.
+    /// Returns null if the key is absent or the value is not a valid long.
+    /// </summary>
+    internal static long? ExtractRetryAfterMs(Metadata? trailers)
+    {
+        if (trailers is null)
+        {
+            return null;
+        }
+
+        foreach (var entry in trailers)
+        {
+            if (string.Equals(entry.Key, "retry-after-ms", StringComparison.OrdinalIgnoreCase)
+                && long.TryParse(entry.Value, out var ms))
+            {
+                return ms;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts authentication scheme and identity hint from request metadata.
+    /// The identity hint is a truncated SHA-256 hash — never the raw credential.
+    /// </summary>
+    internal static (string? AuthScheme, string? IdentityHint) ExtractAuthInfo(Metadata? metadata)
+    {
+        if (metadata is null)
+        {
+            return (null, null);
+        }
+
+        string? authValue = null;
+        foreach (var entry in metadata)
+        {
+            if (string.Equals(entry.Key, "authorization", StringComparison.OrdinalIgnoreCase))
+            {
+                authValue = entry.Value;
+                break;
+            }
+        }
+
+        if (authValue is null)
+        {
+            return (null, null);
+        }
+
+        var spaceIndex = authValue.IndexOf(' ', StringComparison.Ordinal);
+        if (spaceIndex <= 0)
+        {
+            return (authValue, null); // Scheme only, no token part
+        }
+
+        var scheme = authValue[..spaceIndex];
+        var token = authValue[(spaceIndex + 1)..];
+        var hint = HashIdentity(token);
+
+        return (scheme, hint);
+    }
+
+    /// <summary>
+    /// Produces a truncated SHA-256 hash of the input (first 8 bytes as 16 hex chars).
+    /// Used for identity hints — never log raw credentials.
+    /// </summary>
+    internal static string HashIdentity(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexStringLower(bytes)[..16];
+    }
+}

--- a/src/OtelEvents.Grpc/OtelEventsGrpcClientInterceptor.cs
+++ b/src/OtelEvents.Grpc/OtelEventsGrpcClientInterceptor.cs
@@ -58,6 +58,8 @@ internal sealed class OtelEventsGrpcClientInterceptor : Interceptor
             causalScope = OtelEventsCausalityContext.SetParent(Uuid7.FormatEventId());
         }
 
+        var endpoint = context.Host;
+        var requestMetadata = context.Options.Headers;
         var sw = Stopwatch.StartNew();
 
         try
@@ -66,7 +68,8 @@ internal sealed class OtelEventsGrpcClientInterceptor : Interceptor
 
             // Wrap the response task to emit completed/failed on completion
             var wrappedResponseAsync = WrapResponseAsync(
-                call.ResponseAsync, serviceName, methodName, sw, causalScope);
+                call.ResponseAsync, serviceName, methodName, sw, causalScope,
+                endpoint, requestMetadata);
 
             return new AsyncUnaryCall<TResponse>(
                 wrappedResponseAsync,
@@ -79,6 +82,9 @@ internal sealed class OtelEventsGrpcClientInterceptor : Interceptor
         {
             sw.Stop();
             EmitFailed(serviceName, methodName, (int)ex.StatusCode, ex.Status.Detail, sw.Elapsed.TotalMilliseconds, ex);
+            GrpcInfrastructureEvents.TryEmitInfrastructureEvent(
+                _logger, _options, serviceName, methodName, Side, ex,
+                sw.Elapsed.TotalMilliseconds, endpoint, requestMetadata);
             causalScope?.Dispose();
             throw;
         }
@@ -122,7 +128,9 @@ internal sealed class OtelEventsGrpcClientInterceptor : Interceptor
         string serviceName,
         string methodName,
         Stopwatch sw,
-        IDisposable? causalScope)
+        IDisposable? causalScope,
+        string? endpoint,
+        Metadata? requestMetadata)
     {
         try
         {
@@ -142,6 +150,9 @@ internal sealed class OtelEventsGrpcClientInterceptor : Interceptor
         {
             sw.Stop();
             EmitFailed(serviceName, methodName, (int)ex.StatusCode, ex.Status.Detail, sw.Elapsed.TotalMilliseconds, ex);
+            GrpcInfrastructureEvents.TryEmitInfrastructureEvent(
+                _logger, _options, serviceName, methodName, Side, ex,
+                sw.Elapsed.TotalMilliseconds, endpoint, requestMetadata);
             throw;
         }
         catch (Exception ex)

--- a/src/OtelEvents.Grpc/OtelEventsGrpcOptions.cs
+++ b/src/OtelEvents.Grpc/OtelEventsGrpcOptions.cs
@@ -50,4 +50,12 @@ public sealed class OtelEventsGrpcOptions
     /// Default: false — opt-in only to avoid capturing sensitive headers.
     /// </summary>
     public bool CaptureMetadata { get; set; }
+
+    /// <summary>
+    /// Emit supplemental infrastructure events (10104–10106) for connection failures,
+    /// authentication errors, and throttling. These events fire alongside grpc.call.failed
+    /// to provide domain-specific detail for observability dashboards and alerting.
+    /// Default: true.
+    /// </summary>
+    public bool EmitInfrastructureEvents { get; set; } = true;
 }

--- a/src/OtelEvents.Grpc/OtelEventsGrpcServerInterceptor.cs
+++ b/src/OtelEvents.Grpc/OtelEventsGrpcServerInterceptor.cs
@@ -78,6 +78,9 @@ internal sealed class OtelEventsGrpcServerInterceptor : Interceptor
         {
             sw.Stop();
             EmitFailed(serviceName, methodName, (int)ex.StatusCode, ex.Status.Detail, sw.Elapsed.TotalMilliseconds, ex);
+            GrpcInfrastructureEvents.TryEmitInfrastructureEvent(
+                _logger, _options, serviceName, methodName, Side, ex,
+                sw.Elapsed.TotalMilliseconds, context.Peer, context.RequestHeaders);
             throw; // Re-throw — interceptor observes, never swallows
         }
         catch (Exception ex)
@@ -134,6 +137,9 @@ internal sealed class OtelEventsGrpcServerInterceptor : Interceptor
         {
             sw.Stop();
             EmitFailed(serviceName, methodName, (int)ex.StatusCode, ex.Status.Detail, sw.Elapsed.TotalMilliseconds, ex);
+            GrpcInfrastructureEvents.TryEmitInfrastructureEvent(
+                _logger, _options, serviceName, methodName, Side, ex,
+                sw.Elapsed.TotalMilliseconds, context.Peer, context.RequestHeaders);
             throw;
         }
         catch (Exception ex)
@@ -190,6 +196,9 @@ internal sealed class OtelEventsGrpcServerInterceptor : Interceptor
         {
             sw.Stop();
             EmitFailed(serviceName, methodName, (int)ex.StatusCode, ex.Status.Detail, sw.Elapsed.TotalMilliseconds, ex);
+            GrpcInfrastructureEvents.TryEmitInfrastructureEvent(
+                _logger, _options, serviceName, methodName, Side, ex,
+                sw.Elapsed.TotalMilliseconds, context.Peer, context.RequestHeaders);
             throw;
         }
         catch (Exception ex)
@@ -246,6 +255,9 @@ internal sealed class OtelEventsGrpcServerInterceptor : Interceptor
         {
             sw.Stop();
             EmitFailed(serviceName, methodName, (int)ex.StatusCode, ex.Status.Detail, sw.Elapsed.TotalMilliseconds, ex);
+            GrpcInfrastructureEvents.TryEmitInfrastructureEvent(
+                _logger, _options, serviceName, methodName, Side, ex,
+                sw.Elapsed.TotalMilliseconds, context.Peer, context.RequestHeaders);
             throw;
         }
         catch (Exception ex)

--- a/src/OtelEvents.Grpc/Schemas/grpc.all.yaml
+++ b/src/OtelEvents.Grpc/Schemas/grpc.all.yaml
@@ -182,3 +182,133 @@ events:
     tags:
       - grpc
       - error
+
+  # ─── Infrastructure Events (10104–10106) ─────────────────────────────
+  # Supplemental events that fire alongside grpc.call.failed (10103).
+  # Controlled by OtelEventsGrpcOptions.EmitInfrastructureEvents (default: true).
+
+  grpc.connection.failed:
+    id: 10104
+    severity: ERROR
+    description: "A gRPC call failed due to a connection issue (StatusCode.Unavailable)."
+    message: "gRPC {grpcSide} connection to {grpcService}/{grpcMethod} failed: {failureReason}"
+    exception: true
+    fields:
+      grpcService:
+        ref: grpcService
+        required: true
+      grpcMethod:
+        ref: grpcMethod
+        required: true
+      grpcSide:
+        ref: grpcSide
+        required: true
+      endpoint:
+        type: string
+        description: "The endpoint involved in the failure (host for client, peer for server)"
+        required: false
+      durationMs:
+        ref: durationMs
+        required: true
+      errorType:
+        ref: errorType
+        required: true
+      errorMessage:
+        type: string
+        description: "Exception message"
+        required: false
+      failureReason:
+        type: string
+        description: "gRPC status detail explaining the connection failure"
+        required: false
+    metrics:
+      otel.grpc.connection.failed.count:
+        type: counter
+        unit: "errors"
+        description: "gRPC connection failures"
+        labels:
+          - grpcService
+          - grpcMethod
+          - grpcSide
+    tags:
+      - grpc
+      - infrastructure
+      - connection
+
+  grpc.auth.failed:
+    id: 10105
+    severity: ERROR
+    description: "A gRPC call failed due to authentication or authorization (Unauthenticated/PermissionDenied)."
+    message: "gRPC {grpcSide} auth failed for {grpcService}/{grpcMethod} with HTTP {httpStatusCode}"
+    exception: true
+    fields:
+      grpcService:
+        ref: grpcService
+        required: true
+      grpcMethod:
+        ref: grpcMethod
+        required: true
+      grpcSide:
+        ref: grpcSide
+        required: true
+      httpStatusCode:
+        type: int
+        description: "Mapped HTTP status code (401 for Unauthenticated, 403 for PermissionDenied)"
+        index: true
+      authScheme:
+        type: string
+        description: "Authentication scheme (e.g., Bearer, Basic) extracted from Authorization header"
+        required: false
+      identityHint:
+        type: string
+        description: "Truncated SHA-256 hash of the credential — never the raw value"
+        required: false
+    metrics:
+      otel.grpc.auth.failed.count:
+        type: counter
+        unit: "errors"
+        description: "gRPC authentication failures"
+        labels:
+          - grpcService
+          - grpcMethod
+          - grpcSide
+          - httpStatusCode
+    tags:
+      - grpc
+      - infrastructure
+      - security
+
+  grpc.throttled:
+    id: 10106
+    severity: WARN
+    description: "A gRPC call was throttled (StatusCode.ResourceExhausted)."
+    message: "gRPC {grpcSide} {grpcService}/{grpcMethod} throttled"
+    exception: true
+    fields:
+      grpcService:
+        ref: grpcService
+        required: true
+      grpcMethod:
+        ref: grpcMethod
+        required: true
+      grpcSide:
+        ref: grpcSide
+        required: true
+      retryAfterMs:
+        type: long
+        description: "Retry delay in ms from trailing metadata (retry-after-ms key)"
+        unit: "ms"
+        required: false
+    metrics:
+      otel.grpc.throttled.count:
+        type: counter
+        unit: "errors"
+        description: "gRPC throttled requests"
+        labels:
+          - grpcService
+          - grpcMethod
+          - grpcSide
+    tags:
+      - grpc
+      - infrastructure
+      - throttle

--- a/tests/OtelEvents.Grpc.Tests/GrpcInfrastructureEventsTests.cs
+++ b/tests/OtelEvents.Grpc.Tests/GrpcInfrastructureEventsTests.cs
@@ -1,0 +1,543 @@
+using OtelEvents.Causality;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using Grpc.Core.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+using OtelEvents.Grpc;
+using OtelEvents.Grpc.Events;
+
+namespace OtelEvents.Grpc.Tests;
+
+/// <summary>
+/// Unit tests for gRPC infrastructure events (10104–10106).
+/// Tests the supplemental events: connection.failed, auth.failed, throttled.
+/// Covers both client and server interceptors.
+/// </summary>
+public class GrpcInfrastructureEventsTests
+{
+    // ─── Test Infrastructure ────────────────────────────────────────────
+
+    private static (OtelEventsGrpcClientInterceptor Interceptor, TestLogExporter Exporter)
+        CreateClientInterceptor(Action<OtelEventsGrpcOptions>? configure = null)
+    {
+        var exporter = new TestLogExporter();
+        var services = new ServiceCollection();
+
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.ParseStateValues = true;
+                options.AddProcessor(new OtelEventsCausalityProcessor());
+                options.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+            });
+        });
+
+        services.AddOtelEventsGrpc(configure ?? (_ => { }));
+
+        var provider = services.BuildServiceProvider();
+        var interceptor = provider.GetRequiredService<OtelEventsGrpcClientInterceptor>();
+
+        return (interceptor, exporter);
+    }
+
+    private static (OtelEventsGrpcServerInterceptor Interceptor, TestLogExporter Exporter)
+        CreateServerInterceptor(Action<OtelEventsGrpcOptions>? configure = null)
+    {
+        var exporter = new TestLogExporter();
+        var services = new ServiceCollection();
+
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.ParseStateValues = true;
+                options.AddProcessor(new OtelEventsCausalityProcessor());
+                options.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+            });
+        });
+
+        services.AddOtelEventsGrpc(configure ?? (_ => { }));
+
+        var provider = services.BuildServiceProvider();
+        var interceptor = provider.GetRequiredService<OtelEventsGrpcServerInterceptor>();
+
+        return (interceptor, exporter);
+    }
+
+    private static Method<string, string> CreateMethod(
+        string serviceName = "greet.Greeter",
+        string methodName = "SayHello")
+    {
+        return new Method<string, string>(
+            type: MethodType.Unary,
+            serviceName: serviceName,
+            name: methodName,
+            requestMarshaller: Marshallers.StringMarshaller,
+            responseMarshaller: Marshallers.StringMarshaller);
+    }
+
+    private static ClientInterceptorContext<string, string> CreateClientContext(
+        Method<string, string>? method = null,
+        Metadata? headers = null)
+    {
+        method ??= CreateMethod();
+        var callOptions = headers is not null
+            ? new CallOptions(headers: headers)
+            : new CallOptions();
+        return new ClientInterceptorContext<string, string>(
+            method,
+            host: "localhost:5001",
+            options: callOptions);
+    }
+
+    private static ServerCallContext CreateMockServerContext(string method = "/greet.Greeter/SayHello")
+    {
+        return TestServerCallContext.Create(
+            method: method,
+            host: "localhost",
+            deadline: DateTime.UtcNow.AddMinutes(1),
+            requestHeaders: new Metadata(),
+            cancellationToken: CancellationToken.None,
+            peer: "ipv4:127.0.0.1:50051",
+            authContext: null,
+            contextPropagationToken: null,
+            writeHeadersFunc: _ => Task.CompletedTask,
+            writeOptionsGetter: () => new WriteOptions(),
+            writeOptionsSetter: _ => { });
+    }
+
+    private static AsyncUnaryCall<string> CreateFailedCall(
+        StatusCode statusCode,
+        string detail,
+        Metadata? trailers = null)
+    {
+        var exception = trailers is not null
+            ? new RpcException(new Status(statusCode, detail), trailers)
+            : new RpcException(new Status(statusCode, detail));
+
+        return new AsyncUnaryCall<string>(
+            responseAsync: Task.FromException<string>(exception),
+            responseHeadersAsync: Task.FromResult(new Metadata()),
+            getStatusFunc: () => new Status(statusCode, detail),
+            getTrailersFunc: () => trailers ?? new Metadata(),
+            disposeAction: () => { });
+    }
+
+    /// <summary>Infrastructure event names for filtering.</summary>
+    private static readonly HashSet<string> InfraEventNames =
+    [
+        "grpc.connection.failed",
+        "grpc.auth.failed",
+        "grpc.throttled"
+    ];
+
+    private static List<TestLogRecord> GetInfraEvents(TestLogExporter exporter) =>
+        exporter.LogRecords
+            .Where(r => r.EventName is not null && InfraEventNames.Contains(r.EventName))
+            .ToList();
+
+    // ─── grpc.connection.failed (10104) ─────────────────────────────────
+
+    [Fact]
+    public async Task Client_Unavailable_EmitsConnectionFailedEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.connection.failed");
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_HasCorrectEventIdAndLevel()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.connection.failed");
+        Assert.Equal(10104, record.EventId.Id);
+        Assert.Equal("grpc.connection.failed", record.EventId.Name);
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesServiceAndMethod()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var method = CreateMethod("orders.OrderService", "CreateOrder");
+        var context = CreateClientContext(method);
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.connection.failed");
+        record.AssertAttribute("GrpcService", "orders.OrderService");
+        record.AssertAttribute("GrpcMethod", "CreateOrder");
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesFailureReason()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "DNS resolution failed"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.connection.failed");
+        record.AssertAttribute("FailureReason", "DNS resolution failed");
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesEndpoint()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext(); // host: "localhost:5001"
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.connection.failed");
+        record.AssertAttribute("endpoint", "localhost:5001");
+    }
+
+    [Fact]
+    public async Task ConnectionFailed_CapturesDurationMs()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.connection.failed");
+        Assert.True(record.Attributes.ContainsKey("durationMs"), "Should capture durationMs");
+        var durationMs = (double)record.Attributes["durationMs"]!;
+        Assert.True(durationMs >= 0, $"Duration should be non-negative, was {durationMs}");
+    }
+
+    // ─── grpc.auth.failed (10105) ───────────────────────────────────────
+
+    [Fact]
+    public async Task Client_Unauthenticated_EmitsAuthFailedEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unauthenticated, "Invalid token"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.auth.failed");
+    }
+
+    [Fact]
+    public async Task Client_PermissionDenied_EmitsAuthFailedEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.PermissionDenied, "Insufficient permissions"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.auth.failed");
+    }
+
+    [Fact]
+    public async Task AuthFailed_HasCorrectEventId()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unauthenticated, "Invalid token"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.auth.failed");
+        Assert.Equal(10105, record.EventId.Id);
+        Assert.Equal("grpc.auth.failed", record.EventId.Name);
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+    }
+
+    [Fact]
+    public async Task AuthFailed_MapsUnauthenticatedToHttp401()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unauthenticated, "Invalid token"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.auth.failed");
+        record.AssertAttribute("HttpStatusCode", 401);
+    }
+
+    [Fact]
+    public async Task AuthFailed_MapsPermissionDeniedToHttp403()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.PermissionDenied, "Insufficient permissions"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.auth.failed");
+        record.AssertAttribute("HttpStatusCode", 403);
+    }
+
+    [Fact]
+    public async Task AuthFailed_HashesIdentityHint_NeverRaw()
+    {
+        // Arrange — provide a Bearer token in request headers
+        var rawToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-payload";
+        var headers = new Metadata { { "authorization", $"Bearer {rawToken}" } };
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext(headers: headers);
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unauthenticated, "Token expired"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.auth.failed");
+        record.AssertAttribute("authScheme", "Bearer");
+
+        // Identity hint must be a SHA-256 hash, never the raw token
+        Assert.True(record.Attributes.ContainsKey("identityHint"),
+            "Should capture identityHint");
+        var identityHint = (string)record.Attributes["identityHint"]!;
+        Assert.DoesNotContain(rawToken, identityHint);
+        Assert.Matches("^[0-9a-f]{16}$", identityHint); // 16 hex chars (first 8 bytes of SHA-256)
+    }
+
+    // ─── grpc.throttled (10106) ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Client_ResourceExhausted_EmitsThrottledEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.ResourceExhausted, "Rate limited"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.throttled");
+    }
+
+    [Fact]
+    public async Task Throttled_HasCorrectEventIdAndLevel()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.ResourceExhausted, "Rate limited"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.throttled");
+        Assert.Equal(10106, record.EventId.Id);
+        Assert.Equal("grpc.throttled", record.EventId.Name);
+        Assert.Equal(LogLevel.Warning, record.LogLevel); // Warning, not Error
+    }
+
+    [Fact]
+    public async Task Throttled_ExtractsRetryAfterMs()
+    {
+        // Arrange — server includes retry-after-ms in trailing metadata
+        var trailers = new Metadata { { "retry-after-ms", "5000" } };
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.ResourceExhausted, "Rate limited", trailers));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert
+        var record = exporter.AssertSingle("grpc.throttled");
+        record.AssertAttribute("retryAfterMs", 5000L);
+    }
+
+    // ─── Feature Toggle & Supplemental Behavior ─────────────────────────
+
+    [Fact]
+    public async Task InfraEvents_NotEmitted_WhenDisabled()
+    {
+        // Arrange — disable infrastructure events
+        var (interceptor, exporter) = CreateClientInterceptor(options =>
+        {
+            options.EmitInfrastructureEvents = false;
+        });
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert — base event emitted, but no infrastructure event
+        exporter.AssertEventEmitted("grpc.call.failed");
+        Assert.Empty(GetInfraEvents(exporter));
+    }
+
+    [Fact]
+    public async Task InfraEvent_SupplementalToCallFailed()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateClientInterceptor();
+        var context = CreateClientContext();
+
+        // Act
+        using var call = interceptor.AsyncUnaryCall(
+            "request", context,
+            (_, _) => CreateFailedCall(StatusCode.Unavailable, "Connection refused"));
+        await Assert.ThrowsAsync<RpcException>(async () => await call.ResponseAsync);
+
+        // Assert — BOTH grpc.call.failed AND grpc.connection.failed are emitted
+        exporter.AssertEventEmitted("grpc.call.failed");
+        exporter.AssertEventEmitted("grpc.connection.failed");
+    }
+
+    // ─── Server-Side Interceptor ────────────────────────────────────────
+
+    [Fact]
+    public async Task Server_Unavailable_EmitsConnectionFailedEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateServerInterceptor();
+        var context = CreateMockServerContext();
+
+        // Act & Assert — server handler throws Unavailable (e.g., downstream dependency down)
+        await Assert.ThrowsAsync<RpcException>(async () =>
+            await interceptor.UnaryServerHandler<string, string>(
+                "request", context,
+                (_, _) => throw new RpcException(
+                    new Status(StatusCode.Unavailable, "Downstream service unavailable"))));
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.connection.failed");
+        var record = exporter.AssertSingle("grpc.connection.failed");
+        Assert.Equal(10104, record.EventId.Id);
+    }
+
+    [Fact]
+    public async Task Server_Unauthenticated_EmitsAuthFailedEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateServerInterceptor();
+        var context = CreateMockServerContext();
+
+        // Act
+        await Assert.ThrowsAsync<RpcException>(async () =>
+            await interceptor.UnaryServerHandler<string, string>(
+                "request", context,
+                (_, _) => throw new RpcException(
+                    new Status(StatusCode.Unauthenticated, "Missing credentials"))));
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.auth.failed");
+        var record = exporter.AssertSingle("grpc.auth.failed");
+        record.AssertAttribute("HttpStatusCode", 401);
+    }
+
+    [Fact]
+    public async Task Server_ResourceExhausted_EmitsThrottledEvent()
+    {
+        // Arrange
+        var (interceptor, exporter) = CreateServerInterceptor();
+        var context = CreateMockServerContext();
+
+        // Act
+        await Assert.ThrowsAsync<RpcException>(async () =>
+            await interceptor.UnaryServerHandler<string, string>(
+                "request", context,
+                (_, _) => throw new RpcException(
+                    new Status(StatusCode.ResourceExhausted, "Too many requests"))));
+
+        // Assert
+        exporter.AssertEventEmitted("grpc.throttled");
+        var record = exporter.AssertSingle("grpc.throttled");
+        Assert.Equal(LogLevel.Warning, record.LogLevel);
+    }
+}

--- a/tests/OtelEvents.Grpc.Tests/OtelEventsGrpcOptionsTests.cs
+++ b/tests/OtelEvents.Grpc.Tests/OtelEventsGrpcOptionsTests.cs
@@ -45,6 +45,13 @@ public class OtelEventsGrpcOptionsTests
     }
 
     [Fact]
+    public void DefaultOptions_EmitInfrastructureEvents_IsTrue()
+    {
+        var options = new OtelEventsGrpcOptions();
+        Assert.True(options.EmitInfrastructureEvents);
+    }
+
+    [Fact]
     public void DefaultOptions_ExcludeServices_IsEmpty()
     {
         var options = new OtelEventsGrpcOptions();
@@ -69,6 +76,7 @@ public class OtelEventsGrpcOptionsTests
             EnableClientInterceptor = false,
             CaptureMessageSize = false,
             CaptureMetadata = true,
+            EmitInfrastructureEvents = false,
             ExcludeServices = ["grpc.health.v1.Health"],
             ExcludeMethods = ["/grpc.reflection.v1.ServerReflection/ServerReflectionInfo"]
         };
@@ -79,6 +87,7 @@ public class OtelEventsGrpcOptionsTests
         Assert.False(options.EnableClientInterceptor);
         Assert.False(options.CaptureMessageSize);
         Assert.True(options.CaptureMetadata);
+        Assert.False(options.EmitInfrastructureEvents);
         Assert.Single(options.ExcludeServices);
         Assert.Single(options.ExcludeMethods);
     }


### PR DESCRIPTION
Adds 3 infrastructure events to OtelEvents.Grpc:
- `grpc.connection.failed` (10104) — StatusCode.Unavailable
- `grpc.auth.failed` (10105) — Unauthenticated/PermissionDenied with SHA-256 identity hint
- `grpc.throttled` (10106) — ResourceExhausted with retry-after-ms from trailing metadata
18 new tests. Part of #6.