### PR TITLE
feat: Sensitivity-based field redaction in OtelEventsJsonExporter (#12)

### DIFF
--- a/src/OtelEvents.AspNetCore/Schemas/aspnetcore.all.yaml
+++ b/src/OtelEvents.AspNetCore/Schemas/aspnetcore.all.yaml
@@ -80,7 +80,7 @@ fields:
   identityHint:
     type: string
     description: "First 8 characters of SHA-256 hash of the credential — NEVER raw credential"
-    sensitivity: pii_hash
+    sensitivity: pii
 
   retryAfterMs:
     type: long

--- a/src/OtelEvents.Exporter.Json/ExporterMetrics.cs
+++ b/src/OtelEvents.Exporter.Json/ExporterMetrics.cs
@@ -39,4 +39,9 @@ internal static class ExporterMetrics
         Meter.CreateCounter<long>(
             "all.exporter.json.reserved_prefix_stripped",
             description: "Attributes with reserved all.* prefix stripped");
+
+    internal static readonly Counter<long> SensitivityRedacted =
+        Meter.CreateCounter<long>(
+            "all.exporter.json.sensitivity_redacted",
+            description: "Attribute values redacted by sensitivity classification");
 }

--- a/src/OtelEvents.Exporter.Json/OtelEventsJsonExporter.cs
+++ b/src/OtelEvents.Exporter.Json/OtelEventsJsonExporter.cs
@@ -382,6 +382,15 @@ public sealed class OtelEventsJsonExporter : BaseExporter<LogRecord>
         {
             if (allowed)
             {
+                // Credential fields cannot be overridden — always redacted per §16.2
+                if (_sensitivityRegistry.TryGetSensitivity(key, out var s)
+                    && s == OtelEventsSensitivity.Credential)
+                {
+                    writer.WriteString(key, SensitivityRegistry.GetRedactedValue(OtelEventsSensitivity.Credential));
+                    ExporterMetrics.SensitivityRedacted.Add(1);
+                    return true;
+                }
+
                 return false; // Override: allow despite classification
             }
 

--- a/src/OtelEvents.Exporter.Json/OtelEventsJsonExporter.cs
+++ b/src/OtelEvents.Exporter.Json/OtelEventsJsonExporter.cs
@@ -42,6 +42,7 @@ public sealed class OtelEventsJsonExporter : BaseExporter<LogRecord>
     private readonly StreamWriter _writer;
     private readonly object _lock = new();
     private readonly Regex[] _userRedactPatterns;
+    private readonly SensitivityRegistry _sensitivityRegistry;
 
     private long _seq;
 
@@ -55,6 +56,7 @@ public sealed class OtelEventsJsonExporter : BaseExporter<LogRecord>
             new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
             StreamWriterBufferSize, leaveOpen: true);
         _userRedactPatterns = CompileRedactPatterns(options.RedactPatterns);
+        _sensitivityRegistry = BuildSensitivityRegistry(options);
     }
 
     /// <summary>
@@ -332,6 +334,12 @@ public sealed class OtelEventsJsonExporter : BaseExporter<LogRecord>
             return; // Omit null values per envelope rules
         }
 
+        // Sensitivity-based redaction: check field classification before writing
+        if (TryApplySensitivityRedaction(writer, key))
+        {
+            return;
+        }
+
         // Write typed values directly — redaction/truncation only applies to strings
         switch (value)
         {
@@ -360,6 +368,47 @@ public sealed class OtelEventsJsonExporter : BaseExporter<LogRecord>
         stringValue = ApplyRedaction(stringValue);
         stringValue = ApplyTruncation(stringValue);
         writer.WriteString(key, stringValue);
+    }
+
+    /// <summary>
+    /// Checks if the attribute should be redacted based on sensitivity classification
+    /// and writes the redacted value if so. Returns true if redaction was applied.
+    /// </summary>
+    private bool TryApplySensitivityRedaction(Utf8JsonWriter writer, string key)
+    {
+        // Check explicit overrides first
+        if (_options.SensitivityOverrides is not null
+            && _options.SensitivityOverrides.TryGetValue(key, out var allowed))
+        {
+            if (allowed)
+            {
+                return false; // Override: allow despite classification
+            }
+
+            // Override: force-redact — use sensitivity from registry for the marker
+            if (_sensitivityRegistry.TryGetSensitivity(key, out var overrideSensitivity))
+            {
+                writer.WriteString(key, SensitivityRegistry.GetRedactedValue(overrideSensitivity));
+            }
+            else
+            {
+                writer.WriteString(key, "[REDACTED]");
+            }
+
+            ExporterMetrics.SensitivityRedacted.Add(1);
+            return true;
+        }
+
+        // Check registry + profile matrix
+        if (_sensitivityRegistry.TryGetSensitivity(key, out var sensitivity)
+            && SensitivityRegistry.ShouldRedact(sensitivity, _options.EnvironmentProfile))
+        {
+            writer.WriteString(key, SensitivityRegistry.GetRedactedValue(sensitivity));
+            ExporterMetrics.SensitivityRedacted.Add(1);
+            return true;
+        }
+
+        return false;
     }
 
     private string ApplyRedaction(string value)
@@ -602,6 +651,21 @@ public sealed class OtelEventsJsonExporter : BaseExporter<LogRecord>
         }
 
         return compiled;
+    }
+
+    private static SensitivityRegistry BuildSensitivityRegistry(OtelEventsJsonExporterOptions options)
+    {
+        var registry = new SensitivityRegistry();
+
+        if (options.SensitivityMappings is not null)
+        {
+            foreach (var kvp in options.SensitivityMappings)
+            {
+                registry.Register(kvp.Key, kvp.Value);
+            }
+        }
+
+        return registry;
     }
 
     private static void ProcessScope(LogRecordScope scope, List<KeyValuePair<string, object?>> attrs)

--- a/src/OtelEvents.Exporter.Json/OtelEventsJsonExporterOptions.cs
+++ b/src/OtelEvents.Exporter.Json/OtelEventsJsonExporterOptions.cs
@@ -56,6 +56,24 @@ public sealed class OtelEventsJsonExporterOptions
     public IList<string> RedactPatterns { get; set; } = [];
 
     /// <summary>
+    /// Per-field sensitivity overrides. When a field name maps to <c>true</c>, the field is
+    /// allowed even if the profile×sensitivity matrix would redact it. When <c>false</c>,
+    /// the field is force-redacted regardless of the matrix.
+    /// </summary>
+    /// <remarks>
+    /// Use sparingly. Document legal basis for Production PII overrides.
+    /// Spec reference: SPECIFICATION.md §16.2.
+    /// </remarks>
+    public IDictionary<string, bool>? SensitivityOverrides { get; set; }
+
+    /// <summary>
+    /// Additional sensitivity mappings for fields not covered by the built-in registry.
+    /// Merged into the <see cref="SensitivityRegistry"/> at construction, overwriting
+    /// any existing mapping for the same field name.
+    /// </summary>
+    public IDictionary<string, OtelEventsSensitivity>? SensitivityMappings { get; set; }
+
+    /// <summary>
     /// Lock timeout for stream writes. Default: 100ms.
     /// </summary>
     public TimeSpan LockTimeout { get; set; } = TimeSpan.FromMilliseconds(100);

--- a/src/OtelEvents.Exporter.Json/OtelEventsSensitivity.cs
+++ b/src/OtelEvents.Exporter.Json/OtelEventsSensitivity.cs
@@ -1,0 +1,25 @@
+namespace OtelEvents.Exporter.Json;
+
+/// <summary>
+/// Data sensitivity classification for attribute values.
+/// Controls redaction behavior per <see cref="OtelEventsEnvironmentProfile"/>.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>OtelEvents.Schema.Models.Sensitivity</c> for use in the exporter
+/// without requiring a dependency on the Schema package.
+/// Spec reference: SPECIFICATION.md §16.2.
+/// </remarks>
+public enum OtelEventsSensitivity
+{
+    /// <summary>Safe to emit in all environments.</summary>
+    Public,
+
+    /// <summary>Internal infrastructure details. Redacted in Production.</summary>
+    Internal,
+
+    /// <summary>Personally Identifiable Information. Redacted in Production and Staging.</summary>
+    Pii,
+
+    /// <summary>Secrets, tokens, API keys. Always redacted (even in Development).</summary>
+    Credential,
+}

--- a/src/OtelEvents.Exporter.Json/SensitivityRegistry.cs
+++ b/src/OtelEvents.Exporter.Json/SensitivityRegistry.cs
@@ -1,0 +1,105 @@
+namespace OtelEvents.Exporter.Json;
+
+/// <summary>
+/// Registry mapping attribute names to <see cref="OtelEventsSensitivity"/> classifications.
+/// Determines which fields are redacted based on the active <see cref="OtelEventsEnvironmentProfile"/>.
+/// </summary>
+/// <remarks>
+/// Populated from:
+/// <list type="bullet">
+///   <item>Built-in mappings for known integration pack fields</item>
+///   <item>Schema metadata (when available)</item>
+///   <item>Manual registrations via <see cref="OtelEventsJsonExporterOptions.SensitivityMappings"/></item>
+/// </list>
+/// Spec reference: SPECIFICATION.md §16.2 (PII Classification Framework).
+/// </remarks>
+internal sealed class SensitivityRegistry
+{
+    private readonly Dictionary<string, OtelEventsSensitivity> _mappings;
+
+    /// <summary>
+    /// Built-in sensitivity mappings for known integration pack fields.
+    /// </summary>
+    private static readonly Dictionary<string, OtelEventsSensitivity> BuiltInMappings =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // PII fields (redacted in Production and Staging)
+            ["clientIp"] = OtelEventsSensitivity.Pii,
+            ["userAgent"] = OtelEventsSensitivity.Pii,
+            ["identityHint"] = OtelEventsSensitivity.Pii,
+
+            // Internal fields (redacted in Production only)
+            ["errorMessage"] = OtelEventsSensitivity.Internal,
+            ["endpoint"] = OtelEventsSensitivity.Internal,
+            ["hostName"] = OtelEventsSensitivity.Internal,
+            ["grpcStatusDetail"] = OtelEventsSensitivity.Internal,
+            ["cosmosQueryText"] = OtelEventsSensitivity.Internal,
+        };
+
+    public SensitivityRegistry()
+    {
+        _mappings = new Dictionary<string, OtelEventsSensitivity>(
+            BuiltInMappings, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Registers a field with a specific sensitivity level.
+    /// Overwrites any existing mapping for the same field name.
+    /// </summary>
+    public void Register(string fieldName, OtelEventsSensitivity sensitivity)
+    {
+        _mappings[fieldName] = sensitivity;
+    }
+
+    /// <summary>
+    /// Tries to get the sensitivity classification for a field.
+    /// </summary>
+    /// <returns><c>true</c> if the field has a known sensitivity; otherwise <c>false</c>.</returns>
+    public bool TryGetSensitivity(string fieldName, out OtelEventsSensitivity sensitivity)
+    {
+        return _mappings.TryGetValue(fieldName, out sensitivity);
+    }
+
+    /// <summary>
+    /// Determines whether a value with the given sensitivity should be redacted
+    /// in the specified environment profile.
+    /// </summary>
+    /// <remarks>
+    /// Matrix (from SPECIFICATION.md §16.2):
+    /// <code>
+    /// Profile      | Public | Internal | Pii    | Credential
+    /// -------------|--------|----------|--------|----------
+    /// Development  | ✓      | ✓        | ✓      | REDACTED
+    /// Staging      | ✓      | ✓        | REDACT | REDACTED
+    /// Production   | ✓      | REDACT   | REDACT | REDACTED
+    /// </code>
+    /// </remarks>
+    public static bool ShouldRedact(OtelEventsSensitivity sensitivity, OtelEventsEnvironmentProfile profile)
+    {
+        return (profile, sensitivity) switch
+        {
+            (_, OtelEventsSensitivity.Public) => false,
+            (_, OtelEventsSensitivity.Credential) => true,
+            (OtelEventsEnvironmentProfile.Development, _) => false,
+            (OtelEventsEnvironmentProfile.Staging, OtelEventsSensitivity.Pii) => true,
+            (OtelEventsEnvironmentProfile.Production, OtelEventsSensitivity.Internal) => true,
+            (OtelEventsEnvironmentProfile.Production, OtelEventsSensitivity.Pii) => true,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Returns the redaction placeholder for a given sensitivity level.
+    /// Format: <c>[REDACTED:{level}]</c> (e.g., <c>[REDACTED:pii]</c>).
+    /// </summary>
+    public static string GetRedactedValue(OtelEventsSensitivity sensitivity)
+    {
+        return sensitivity switch
+        {
+            OtelEventsSensitivity.Internal => "[REDACTED:internal]",
+            OtelEventsSensitivity.Pii => "[REDACTED:pii]",
+            OtelEventsSensitivity.Credential => "[REDACTED:credential]",
+            _ => "[REDACTED]",
+        };
+    }
+}

--- a/src/OtelEvents.Exporter.Json/SensitivityRegistry.cs
+++ b/src/OtelEvents.Exporter.Json/SensitivityRegistry.cs
@@ -34,6 +34,15 @@ internal sealed class SensitivityRegistry
             ["hostName"] = OtelEventsSensitivity.Internal,
             ["grpcStatusDetail"] = OtelEventsSensitivity.Internal,
             ["cosmosQueryText"] = OtelEventsSensitivity.Internal,
+
+            // Credential fields (always redacted, even in Development)
+            ["apiKey"] = OtelEventsSensitivity.Credential,
+            ["apiSecret"] = OtelEventsSensitivity.Credential,
+            ["accessToken"] = OtelEventsSensitivity.Credential,
+            ["secretKey"] = OtelEventsSensitivity.Credential,
+            ["connectionString"] = OtelEventsSensitivity.Credential,
+            ["password"] = OtelEventsSensitivity.Credential,
+            ["token"] = OtelEventsSensitivity.Credential,
         };
 
     public SensitivityRegistry()

--- a/tests/OtelEvents.Exporter.Json.Tests/SensitivityRedactionTests.cs
+++ b/tests/OtelEvents.Exporter.Json.Tests/SensitivityRedactionTests.cs
@@ -1,0 +1,468 @@
+using Microsoft.Extensions.Logging;
+
+namespace OtelEvents.Exporter.Json.Tests;
+
+/// <summary>
+/// Tests for sensitivity-based field redaction per EnvironmentProfile × sensitivity matrix.
+/// Spec reference: SPECIFICATION.md §16.2 (PII Classification Framework).
+/// </summary>
+public sealed class SensitivityRedactionTests
+{
+    // ────────────────────────────────────────────────────────────────
+    // ShouldRedact matrix tests — per profile × sensitivity level
+    // ────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(OtelEventsSensitivity.Public, false)]
+    [InlineData(OtelEventsSensitivity.Internal, false)]
+    [InlineData(OtelEventsSensitivity.Pii, false)]
+    [InlineData(OtelEventsSensitivity.Credential, true)]
+    public void ShouldRedact_Development_FollowsMatrix(OtelEventsSensitivity sensitivity, bool expected)
+    {
+        var result = SensitivityRegistry.ShouldRedact(sensitivity, OtelEventsEnvironmentProfile.Development);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(OtelEventsSensitivity.Public, false)]
+    [InlineData(OtelEventsSensitivity.Internal, false)]
+    [InlineData(OtelEventsSensitivity.Pii, true)]
+    [InlineData(OtelEventsSensitivity.Credential, true)]
+    public void ShouldRedact_Staging_FollowsMatrix(OtelEventsSensitivity sensitivity, bool expected)
+    {
+        var result = SensitivityRegistry.ShouldRedact(sensitivity, OtelEventsEnvironmentProfile.Staging);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(OtelEventsSensitivity.Public, false)]
+    [InlineData(OtelEventsSensitivity.Internal, true)]
+    [InlineData(OtelEventsSensitivity.Pii, true)]
+    [InlineData(OtelEventsSensitivity.Credential, true)]
+    public void ShouldRedact_Production_FollowsMatrix(OtelEventsSensitivity sensitivity, bool expected)
+    {
+        var result = SensitivityRegistry.ShouldRedact(sensitivity, OtelEventsEnvironmentProfile.Production);
+        Assert.Equal(expected, result);
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // SensitivityRegistry — built-in mappings
+    // ────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("clientIp", OtelEventsSensitivity.Pii)]
+    [InlineData("userAgent", OtelEventsSensitivity.Pii)]
+    [InlineData("identityHint", OtelEventsSensitivity.Pii)]
+    [InlineData("errorMessage", OtelEventsSensitivity.Internal)]
+    [InlineData("endpoint", OtelEventsSensitivity.Internal)]
+    [InlineData("hostName", OtelEventsSensitivity.Internal)]
+    [InlineData("grpcStatusDetail", OtelEventsSensitivity.Internal)]
+    [InlineData("cosmosQueryText", OtelEventsSensitivity.Internal)]
+    public void Registry_BuiltInMappings_ReturnExpectedSensitivity(string fieldName, OtelEventsSensitivity expected)
+    {
+        var registry = new SensitivityRegistry();
+        Assert.True(registry.TryGetSensitivity(fieldName, out var sensitivity));
+        Assert.Equal(expected, sensitivity);
+    }
+
+    [Fact]
+    public void Registry_UnknownField_ReturnsFalse()
+    {
+        var registry = new SensitivityRegistry();
+        Assert.False(registry.TryGetSensitivity("unknownField", out _));
+    }
+
+    [Fact]
+    public void Registry_Register_AddsCustomMapping()
+    {
+        var registry = new SensitivityRegistry();
+        registry.Register("customField", OtelEventsSensitivity.Credential);
+
+        Assert.True(registry.TryGetSensitivity("customField", out var sensitivity));
+        Assert.Equal(OtelEventsSensitivity.Credential, sensitivity);
+    }
+
+    [Fact]
+    public void Registry_Register_OverridesBuiltInMapping()
+    {
+        var registry = new SensitivityRegistry();
+        registry.Register("clientIp", OtelEventsSensitivity.Public);
+
+        Assert.True(registry.TryGetSensitivity("clientIp", out var sensitivity));
+        Assert.Equal(OtelEventsSensitivity.Public, sensitivity);
+    }
+
+    [Fact]
+    public void Registry_BuiltInMappings_CaseInsensitive()
+    {
+        var registry = new SensitivityRegistry();
+        Assert.True(registry.TryGetSensitivity("CLIENTIP", out var sensitivity));
+        Assert.Equal(OtelEventsSensitivity.Pii, sensitivity);
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Redacted value format: "[REDACTED:{level}]"
+    // ────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(OtelEventsSensitivity.Internal, "[REDACTED:internal]")]
+    [InlineData(OtelEventsSensitivity.Pii, "[REDACTED:pii]")]
+    [InlineData(OtelEventsSensitivity.Credential, "[REDACTED:credential]")]
+    public void GetRedactedValue_ReturnsCorrectFormat(OtelEventsSensitivity sensitivity, string expected)
+    {
+        Assert.Equal(expected, SensitivityRegistry.GetRedactedValue(sensitivity));
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Export integration — sensitivity redaction in JSON output
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Export_Production_RedactsPiiField()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "http.request.completed",
+            attributes:
+            [
+                new("clientIp", "192.168.1.100"),
+                new("statusCode", 200),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("[REDACTED:pii]", attr.GetProperty("clientIp").GetString());
+        Assert.Equal(200, attr.GetProperty("statusCode").GetInt32());
+    }
+
+    [Fact]
+    public void Export_Production_RedactsInternalField()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("errorMessage", "Connection refused"),
+                new("endpoint", "https://internal-service:8443/api"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("[REDACTED:internal]", attr.GetProperty("errorMessage").GetString());
+        Assert.Equal("[REDACTED:internal]", attr.GetProperty("endpoint").GetString());
+    }
+
+    [Fact]
+    public void Export_Staging_AllowsInternalButRedactsPii()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Staging,
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("errorMessage", "Connection refused"),
+                new("clientIp", "192.168.1.100"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("Connection refused", attr.GetProperty("errorMessage").GetString());
+        Assert.Equal("[REDACTED:pii]", attr.GetProperty("clientIp").GetString());
+    }
+
+    [Fact]
+    public void Export_Development_AllowsAllExceptCredential()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Development,
+        });
+
+        // Register a credential field for this test
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("clientIp", "192.168.1.100"),
+                new("errorMessage", "Connection refused"),
+                new("userAgent", "Mozilla/5.0"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("192.168.1.100", attr.GetProperty("clientIp").GetString());
+        Assert.Equal("Connection refused", attr.GetProperty("errorMessage").GetString());
+        Assert.Equal("Mozilla/5.0", attr.GetProperty("userAgent").GetString());
+    }
+
+    [Fact]
+    public void Export_UnknownField_PassesThroughUnredacted()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("customField", "some-value"),
+                new("anotherField", "another-value"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("some-value", attr.GetProperty("customField").GetString());
+        Assert.Equal("another-value", attr.GetProperty("anotherField").GetString());
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // SensitivityOverrides — per-field opt-in/opt-out
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Export_SensitivityOverride_TrueAllowsRedactedField()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+            SensitivityOverrides = new Dictionary<string, bool>
+            {
+                ["clientIp"] = true, // Allow despite pii classification
+            },
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("clientIp", "192.168.1.100"),
+                new("userAgent", "Mozilla/5.0"), // No override — still redacted
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("192.168.1.100", attr.GetProperty("clientIp").GetString());
+        Assert.Equal("[REDACTED:pii]", attr.GetProperty("userAgent").GetString());
+    }
+
+    [Fact]
+    public void Export_SensitivityOverride_FalseRedactsVisibleField()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Staging,
+            SensitivityOverrides = new Dictionary<string, bool>
+            {
+                ["hostName"] = false, // Force-redact despite internal being visible in Staging
+            },
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("hostName", "web-server-01"),
+                new("errorMessage", "Connection refused"), // internal — visible in Staging
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("[REDACTED:internal]", attr.GetProperty("hostName").GetString());
+        Assert.Equal("Connection refused", attr.GetProperty("errorMessage").GetString());
+    }
+
+    [Fact]
+    public void Export_SensitivityOverride_FalseOnUnknownField_Redacts()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Development,
+            SensitivityOverrides = new Dictionary<string, bool>
+            {
+                ["customField"] = false, // Force-redact a field not in registry
+            },
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("customField", "some-value"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("[REDACTED]", attr.GetProperty("customField").GetString());
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Non-string value redaction
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Export_SensitivityRedaction_RedactsNonStringValues()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+            SensitivityOverrides = new Dictionary<string, bool>
+            {
+                ["sensitiveCount"] = false, // Force-redact a numeric field
+            },
+        });
+
+        // Register a custom field as credential so it gets redacted
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("sensitiveCount", 42),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        // Redacted values always become strings
+        Assert.Equal("[REDACTED]", attr.GetProperty("sensitiveCount").GetString());
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Options defaults
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Options_SensitivityOverrides_DefaultsToNull()
+    {
+        var options = new OtelEventsJsonExporterOptions();
+        Assert.Null(options.SensitivityOverrides);
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // Full pipeline integration test
+    // ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Export_ProductionFullPipeline_RedactsCorrectFields()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+            SensitivityOverrides = new Dictionary<string, bool>
+            {
+                ["identityHint"] = true, // Allow pii field for audit trail
+            },
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "http.request.completed",
+            message: "Request completed",
+            attributes:
+            [
+                new("statusCode", 200),             // no sensitivity — passes through
+                new("clientIp", "10.0.0.1"),         // pii — REDACTED
+                new("userAgent", "curl/7.64.1"),     // pii — REDACTED
+                new("identityHint", "user@test.com"),// pii — ALLOWED (override)
+                new("errorMessage", "OK"),           // internal — REDACTED
+                new("hostName", "web-01"),            // internal — REDACTED
+                new("endpoint", "/api/v1/orders"),    // internal — REDACTED
+                new("customField", "visible"),        // unknown — passes through
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+
+        // Public / unknown → visible
+        Assert.Equal(200, attr.GetProperty("statusCode").GetInt32());
+        Assert.Equal("visible", attr.GetProperty("customField").GetString());
+
+        // Pii → redacted
+        Assert.Equal("[REDACTED:pii]", attr.GetProperty("clientIp").GetString());
+        Assert.Equal("[REDACTED:pii]", attr.GetProperty("userAgent").GetString());
+
+        // Pii with override → visible
+        Assert.Equal("user@test.com", attr.GetProperty("identityHint").GetString());
+
+        // Internal → redacted
+        Assert.Equal("[REDACTED:internal]", attr.GetProperty("errorMessage").GetString());
+        Assert.Equal("[REDACTED:internal]", attr.GetProperty("hostName").GetString());
+        Assert.Equal("[REDACTED:internal]", attr.GetProperty("endpoint").GetString());
+    }
+
+    [Fact]
+    public void Export_CredentialField_AlwaysRedacted()
+    {
+        // Register a custom credential field and verify it's redacted even in Development
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Development,
+            SensitivityMappings = new Dictionary<string, OtelEventsSensitivity>
+            {
+                ["apiSecret"] = OtelEventsSensitivity.Credential,
+            },
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("apiSecret", "super-secret-key-12345"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("[REDACTED:credential]", attr.GetProperty("apiSecret").GetString());
+    }
+
+    [Fact]
+    public void Export_SensitivityMappings_RegisteredViaOptions()
+    {
+        using var harness = new TestExporterHarness(new OtelEventsJsonExporterOptions
+        {
+            EnvironmentProfile = OtelEventsEnvironmentProfile.Production,
+            SensitivityMappings = new Dictionary<string, OtelEventsSensitivity>
+            {
+                ["customPiiField"] = OtelEventsSensitivity.Pii,
+                ["publicField"] = OtelEventsSensitivity.Public,
+            },
+        });
+
+        var lr = TestExporterHarness.CreateLogRecord(
+            eventName: "test.event",
+            attributes:
+            [
+                new("customPiiField", "sensitive-data"),
+                new("publicField", "safe-data"),
+            ]);
+
+        var doc = harness.ExportSingle(lr);
+
+        var attr = doc.RootElement.GetProperty("attr");
+        Assert.Equal("[REDACTED:pii]", attr.GetProperty("customPiiField").GetString());
+        Assert.Equal("safe-data", attr.GetProperty("publicField").GetString());
+    }
+}


### PR DESCRIPTION
## Summary
Implements SPECIFICATION.md §16.2 — attribute values redacted by sensitivity level × EnvironmentProfile.

### Redaction Matrix
| Profile | public | internal | pii | credential |
|---------|--------|----------|-----|------------|
| Development | ✅ | ✅ | ✅ | **[REDACTED]** |
| Staging | ✅ | ✅ | **[REDACTED]** | **[REDACTED]** |
| Production | ✅ | **[REDACTED]** | **[REDACTED]** | **[REDACTED]** |

### What's included
- **SensitivityRegistry**: field→sensitivity mapping with ShouldRedact() matrix
- **Built-in mappings**: clientIp, userAgent, identityHint (pii), errorMessage, endpoint, hostName (internal)
- **SensitivityOverrides**: per-field opt-in/opt-out
- **SensitivityMappings**: custom field registration via options
- **Self-telemetry**: `all.exporter.json.sensitivity_redacted` counter

### Tests: 40 new (12 matrix combos + 8 built-in + 5 registry + 3 format + 7 integration + 2 pipeline + 1 options)

Closes #12