### PR TITLE
feat: Event Subscription System — In-Process Event Bus (#11)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.3" />
     <PackageVersion Include="Azure.Core" Version="1.51.1" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.0" />

--- a/OtelEvents.slnx
+++ b/OtelEvents.slnx
@@ -11,6 +11,7 @@
     <Project Path="src/OtelEvents.Azure.Storage/OtelEvents.Azure.Storage.csproj" />
     <Project Path="src/OtelEvents.Grpc/OtelEvents.Grpc.csproj" />
     <Project Path="src/OtelEvents.HealthChecks/OtelEvents.HealthChecks.csproj" />
+    <Project Path="src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/OtelEvents.Analyzers.Tests/OtelEvents.Analyzers.Tests.csproj" />
@@ -24,6 +25,7 @@
     <Project Path="tests/OtelEvents.Azure.Storage.Tests/OtelEvents.Azure.Storage.Tests.csproj" />
     <Project Path="tests/OtelEvents.Grpc.Tests/OtelEvents.Grpc.Tests.csproj" />
     <Project Path="tests/OtelEvents.HealthChecks.Tests/OtelEvents.HealthChecks.Tests.csproj" />
+    <Project Path="tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/OtelEvents.Cli/OtelEvents.Cli.csproj" />

--- a/src/OtelEvents.Subscriptions/IOtelEventHandler.cs
+++ b/src/OtelEvents.Subscriptions/IOtelEventHandler.cs
@@ -1,0 +1,33 @@
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Interface for DI-resolved event subscription handlers.
+/// <para>
+/// Implement this interface and register with
+/// <see cref="OtelEventsSubscriptionBuilder.AddHandler{THandler}"/> to handle events
+/// resolved through the dependency injection container.
+/// </para>
+/// </summary>
+/// <example>
+/// <code>
+/// public class OrderPlacedHandler : IOtelEventHandler
+/// {
+///     public Task HandleAsync(OtelEventContext context, CancellationToken cancellationToken)
+///     {
+///         var orderId = context.GetAttribute&lt;string&gt;("orderId");
+///         // process the order event
+///         return Task.CompletedTask;
+///     }
+/// }
+/// </code>
+/// </example>
+public interface IOtelEventHandler
+{
+    /// <summary>
+    /// Handles an event subscription notification.
+    /// </summary>
+    /// <param name="context">The immutable event context snapshot.</param>
+    /// <param name="cancellationToken">Cancellation token for cooperative shutdown.</param>
+    /// <returns>A task representing the async handler operation.</returns>
+    Task HandleAsync(OtelEventContext context, CancellationToken cancellationToken);
+}

--- a/src/OtelEvents.Subscriptions/OtelEventContext.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventContext.cs
@@ -70,8 +70,13 @@ public sealed class OtelEventContext
     /// <typeparam name="T">The expected attribute value type.</typeparam>
     /// <param name="key">The attribute key.</param>
     /// <returns>The attribute value cast to <typeparamref name="T"/>, or <c>default</c>.</returns>
-    public T? GetAttribute<T>(string key)
+    public T? GetAttribute<T>(string? key)
     {
+        if (key is null)
+        {
+            return default;
+        }
+
         if (Attributes.TryGetValue(key, out var value) && value is T typed)
         {
             return typed;
@@ -91,7 +96,9 @@ public sealed class OtelEventContext
         {
             foreach (var kvp in record.Attributes)
             {
-                attributes[kvp.Key] = kvp.Value;
+                // Deep-copy array values to avoid sharing mutable state
+                // with recycled LogRecord instances
+                attributes[kvp.Key] = kvp.Value is Array arr ? arr.Clone() : kvp.Value;
             }
         }
 

--- a/src/OtelEvents.Subscriptions/OtelEventContext.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventContext.cs
@@ -43,7 +43,7 @@ public sealed class OtelEventContext
     /// <summary>
     /// Initializes a new instance of <see cref="OtelEventContext"/>.
     /// </summary>
-    internal OtelEventContext(
+    public OtelEventContext(
         string eventName,
         LogLevel logLevel,
         string? formattedMessage,

--- a/src/OtelEvents.Subscriptions/OtelEventContext.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventContext.cs
@@ -1,0 +1,118 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Immutable snapshot of a <see cref="OpenTelemetry.Logs.LogRecord"/> delivered to subscription handlers.
+/// <para>
+/// OpenTelemetry recycles <see cref="OpenTelemetry.Logs.LogRecord"/> instances (they are pooled/mutable),
+/// so this class captures all relevant fields at processing time, allowing safe async handler execution
+/// after the OTEL pipeline has moved on.
+/// </para>
+/// </summary>
+public sealed class OtelEventContext
+{
+    /// <summary>Gets the event name from <c>LogRecord.EventId.Name</c>.</summary>
+    public string EventName { get; }
+
+    /// <summary>Gets the log severity level.</summary>
+    public LogLevel LogLevel { get; }
+
+    /// <summary>Gets the formatted message, if any.</summary>
+    public string? FormattedMessage { get; }
+
+    /// <summary>
+    /// Gets the captured attributes as an immutable dictionary.
+    /// Empty dictionary if no attributes were present on the original record.
+    /// </summary>
+    public IReadOnlyDictionary<string, object?> Attributes { get; }
+
+    /// <summary>Gets the UTC timestamp of the log record.</summary>
+    public DateTimeOffset Timestamp { get; }
+
+    /// <summary>Gets the W3C trace ID as a hex string, or null if not present.</summary>
+    public string? TraceId { get; }
+
+    /// <summary>Gets the W3C span ID as a hex string, or null if not present.</summary>
+    public string? SpanId { get; }
+
+    /// <summary>Gets the exception associated with this log record, if any.</summary>
+    public Exception? Exception { get; }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OtelEventContext"/>.
+    /// </summary>
+    internal OtelEventContext(
+        string eventName,
+        LogLevel logLevel,
+        string? formattedMessage,
+        IReadOnlyDictionary<string, object?> attributes,
+        DateTimeOffset timestamp,
+        string? traceId,
+        string? spanId,
+        Exception? exception)
+    {
+        EventName = eventName;
+        LogLevel = logLevel;
+        FormattedMessage = formattedMessage;
+        Attributes = attributes;
+        Timestamp = timestamp;
+        TraceId = traceId;
+        SpanId = spanId;
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets a typed attribute value by key.
+    /// Returns <c>default</c> if the key is not found or cannot be cast to <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The expected attribute value type.</typeparam>
+    /// <param name="key">The attribute key.</param>
+    /// <returns>The attribute value cast to <typeparamref name="T"/>, or <c>default</c>.</returns>
+    public T? GetAttribute<T>(string key)
+    {
+        if (Attributes.TryGetValue(key, out var value) && value is T typed)
+        {
+            return typed;
+        }
+
+        return default;
+    }
+
+    /// <summary>
+    /// Creates an immutable snapshot from a live <see cref="OpenTelemetry.Logs.LogRecord"/>.
+    /// Copies all fields so the snapshot is safe to use after the record is recycled.
+    /// </summary>
+    internal static OtelEventContext FromLogRecord(OpenTelemetry.Logs.LogRecord record)
+    {
+        var attributes = new Dictionary<string, object?>();
+        if (record.Attributes is not null)
+        {
+            foreach (var kvp in record.Attributes)
+            {
+                attributes[kvp.Key] = kvp.Value;
+            }
+        }
+
+        var traceId = record.TraceId != default(ActivityTraceId)
+            ? record.TraceId.ToString()
+            : null;
+
+        var spanId = record.SpanId != default(ActivitySpanId)
+            ? record.SpanId.ToString()
+            : null;
+
+        return new OtelEventContext(
+            eventName: record.EventId.Name ?? string.Empty,
+            logLevel: record.LogLevel,
+            formattedMessage: record.FormattedMessage,
+            attributes: attributes,
+            timestamp: record.Timestamp != default
+                ? new DateTimeOffset(record.Timestamp, TimeSpan.Zero)
+                : DateTimeOffset.UtcNow,
+            traceId: traceId,
+            spanId: spanId,
+            exception: record.Exception);
+    }
+}

--- a/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
+++ b/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <NoWarn>CA1031;CA1062;CA1711;CA1822;CA2000;CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="OtelEvents.Subscriptions.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
+++ b/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <NoWarn>CA1031;CA1062;CA1711;CA1822;CA2000;CA2007</NoWarn>
+    <NoWarn>CA1031;CA1062;CA1711;CA1822;CA2000;CA2007;CA1848</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionBuilder.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionBuilder.cs
@@ -1,0 +1,150 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Builder for configuring event subscriptions via lambda handlers and DI-resolved handler classes.
+/// Used within the <see cref="OtelEventsSubscriptionExtensions.AddOtelEventsSubscriptions"/> callback.
+/// </summary>
+/// <example>
+/// <code>
+/// builder.Services.AddOtelEventsSubscriptions(subs =>
+/// {
+///     subs.On("cosmosdb.throttled", async (ctx, ct) =>
+///     {
+///         var retryMs = ctx.GetAttribute&lt;long&gt;("retryAfterMs");
+///         await Task.Delay(TimeSpan.FromMilliseconds(retryMs), ct);
+///     });
+///
+///     subs.On("*.auth.failed", (ctx, ct) => Task.CompletedTask);
+///
+///     subs.AddHandler&lt;OrderPlacedHandler&gt;("order.placed");
+/// });
+/// </code>
+/// </example>
+public sealed class OtelEventsSubscriptionBuilder
+{
+    private readonly IServiceCollection _services;
+
+    internal readonly List<SubscriptionRegistration> Registrations = [];
+
+    internal OtelEventsSubscriptionBuilder(IServiceCollection services)
+    {
+        _services = services;
+    }
+
+    /// <summary>
+    /// Registers a lambda handler for events matching the specified pattern.
+    /// </summary>
+    /// <param name="eventPattern">
+    /// Exact event name (e.g., <c>"order.placed"</c>) or wildcard pattern
+    /// with a trailing <c>*</c> (e.g., <c>"cosmosdb.*"</c>).
+    /// </param>
+    /// <param name="handler">The async handler delegate to invoke when an event matches.</param>
+    /// <returns>This builder for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="eventPattern"/> is null or empty.
+    /// </exception>
+    public OtelEventsSubscriptionBuilder On(
+        string eventPattern,
+        Func<OtelEventContext, CancellationToken, Task> handler)
+    {
+        ValidatePattern(eventPattern);
+        ArgumentNullException.ThrowIfNull(handler);
+
+        Registrations.Add(new SubscriptionRegistration(eventPattern, handler));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a DI-resolved handler class for events matching the specified pattern.
+    /// The handler is resolved from the service provider per invocation.
+    /// </summary>
+    /// <typeparam name="THandler">
+    /// The handler type implementing <see cref="IOtelEventHandler"/>.
+    /// Must be registered in DI separately or will be auto-registered as transient.
+    /// </typeparam>
+    /// <param name="eventPattern">
+    /// Exact event name or wildcard pattern with a trailing <c>*</c>.
+    /// </param>
+    /// <returns>This builder for chaining.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="eventPattern"/> is null or empty.
+    /// </exception>
+    public OtelEventsSubscriptionBuilder AddHandler<THandler>(string eventPattern)
+        where THandler : class, IOtelEventHandler
+    {
+        ValidatePattern(eventPattern);
+
+        // Auto-register the handler type as transient if not already registered
+        _services.AddTransient<THandler>();
+
+        Registrations.Add(new SubscriptionRegistration(eventPattern, typeof(THandler)));
+        return this;
+    }
+
+    private static void ValidatePattern(string eventPattern)
+    {
+        if (string.IsNullOrEmpty(eventPattern))
+        {
+            throw new ArgumentException(
+                "Event pattern must not be null or empty.",
+                nameof(eventPattern));
+        }
+
+        if (eventPattern == "*")
+        {
+            throw new ArgumentException(
+                "Bare wildcard \"*\" is not allowed. Use a qualified "
+                + "prefix wildcard like \"health.*\".",
+                nameof(eventPattern));
+        }
+    }
+}
+
+/// <summary>
+/// Internal registration record holding either a lambda handler or a DI handler type.
+/// </summary>
+internal sealed class SubscriptionRegistration
+{
+    /// <summary>The event pattern (exact name or wildcard with trailing *).</summary>
+    public string EventPattern { get; }
+
+    /// <summary>The prefix for wildcard matching (pattern without trailing *), or null for exact match.</summary>
+    public string? WildcardPrefix { get; }
+
+    /// <summary>Whether this registration uses a wildcard pattern.</summary>
+    public bool IsWildcard { get; }
+
+    /// <summary>Lambda handler, if registered via <see cref="OtelEventsSubscriptionBuilder.On"/>.</summary>
+    public Func<OtelEventContext, CancellationToken, Task>? LambdaHandler { get; }
+
+    /// <summary>DI handler type, if registered via <see cref="OtelEventsSubscriptionBuilder.AddHandler{THandler}"/>.</summary>
+    public Type? HandlerType { get; }
+
+    public SubscriptionRegistration(
+        string eventPattern,
+        Func<OtelEventContext, CancellationToken, Task> lambdaHandler)
+    {
+        EventPattern = eventPattern;
+        LambdaHandler = lambdaHandler;
+
+        if (eventPattern.EndsWith('*'))
+        {
+            IsWildcard = true;
+            WildcardPrefix = eventPattern[..^1]; // strip trailing '*'
+        }
+    }
+
+    public SubscriptionRegistration(string eventPattern, Type handlerType)
+    {
+        EventPattern = eventPattern;
+        HandlerType = handlerType;
+
+        if (eventPattern.EndsWith('*'))
+        {
+            IsWildcard = true;
+            WildcardPrefix = eventPattern[..^1];
+        }
+    }
+}

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionBuilder.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionBuilder.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace OtelEvents.Subscriptions;
@@ -77,7 +78,7 @@ public sealed class OtelEventsSubscriptionBuilder
         ValidatePattern(eventPattern);
 
         // Auto-register the handler type as transient if not already registered
-        _services.AddTransient<THandler>();
+        _services.TryAddTransient<THandler>();
 
         Registrations.Add(new SubscriptionRegistration(eventPattern, typeof(THandler)));
         return this;

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionBuilder.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionBuilder.cs
@@ -42,19 +42,22 @@ public sealed class OtelEventsSubscriptionBuilder
     /// with a trailing <c>*</c> (e.g., <c>"cosmosdb.*"</c>).
     /// </param>
     /// <param name="handler">The async handler delegate to invoke when an event matches.</param>
-    /// <returns>This builder for chaining.</returns>
+    /// <returns>
+    /// An <see cref="IDisposable"/> that, when disposed, removes this subscription registration.
+    /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="eventPattern"/> is null or empty.
     /// </exception>
-    public OtelEventsSubscriptionBuilder On(
+    public IDisposable On(
         string eventPattern,
         Func<OtelEventContext, CancellationToken, Task> handler)
     {
         ValidatePattern(eventPattern);
         ArgumentNullException.ThrowIfNull(handler);
 
-        Registrations.Add(new SubscriptionRegistration(eventPattern, handler));
-        return this;
+        var registration = new SubscriptionRegistration(eventPattern, handler);
+        Registrations.Add(registration);
+        return new SubscriptionDisposable(registration, Registrations);
     }
 
     /// <summary>
@@ -68,11 +71,13 @@ public sealed class OtelEventsSubscriptionBuilder
     /// <param name="eventPattern">
     /// Exact event name or wildcard pattern with a trailing <c>*</c>.
     /// </param>
-    /// <returns>This builder for chaining.</returns>
+    /// <returns>
+    /// An <see cref="IDisposable"/> that, when disposed, removes this subscription registration.
+    /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="eventPattern"/> is null or empty.
     /// </exception>
-    public OtelEventsSubscriptionBuilder AddHandler<THandler>(string eventPattern)
+    public IDisposable AddHandler<THandler>(string eventPattern)
         where THandler : class, IOtelEventHandler
     {
         ValidatePattern(eventPattern);
@@ -80,8 +85,9 @@ public sealed class OtelEventsSubscriptionBuilder
         // Auto-register the handler type as transient if not already registered
         _services.TryAddTransient<THandler>();
 
-        Registrations.Add(new SubscriptionRegistration(eventPattern, typeof(THandler)));
-        return this;
+        var registration = new SubscriptionRegistration(eventPattern, typeof(THandler));
+        Registrations.Add(registration);
+        return new SubscriptionDisposable(registration, Registrations);
     }
 
     private static void ValidatePattern(string eventPattern)
@@ -99,6 +105,36 @@ public sealed class OtelEventsSubscriptionBuilder
                 "Bare wildcard \"*\" is not allowed. Use a qualified "
                 + "prefix wildcard like \"health.*\".",
                 nameof(eventPattern));
+        }
+    }
+}
+
+/// <summary>
+/// Removes a <see cref="SubscriptionRegistration"/> from the registrations list when disposed.
+/// Safe to dispose multiple times — subsequent calls are no-ops.
+/// </summary>
+internal sealed class SubscriptionDisposable : IDisposable
+{
+    private SubscriptionRegistration? _registration;
+    private readonly List<SubscriptionRegistration> _registrations;
+
+    public SubscriptionDisposable(
+        SubscriptionRegistration registration,
+        List<SubscriptionRegistration> registrations)
+    {
+        _registration = registration;
+        _registrations = registrations;
+    }
+
+    public void Dispose()
+    {
+        var registration = Interlocked.Exchange(ref _registration, null);
+        if (registration is not null)
+        {
+            lock (_registrations)
+            {
+                _registrations.Remove(registration);
+            }
         }
     }
 }

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionDispatcher.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionDispatcher.cs
@@ -1,0 +1,68 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Background hosted service that reads from the dispatch channel and invokes
+/// subscription handlers. Each handler invocation is wrapped in try-catch
+/// so handler errors never crash the service.
+/// </summary>
+internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
+{
+    private readonly Channel<DispatchItem> _channel;
+    private readonly IServiceProvider _serviceProvider;
+
+    public OtelEventsSubscriptionDispatcher(
+        Channel<DispatchItem> channel,
+        IServiceProvider serviceProvider)
+    {
+        _channel = channel;
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var item in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            foreach (var registration in item.Registrations)
+            {
+                await InvokeHandlerAsync(registration, item.Context, stoppingToken);
+            }
+        }
+    }
+
+    private async Task InvokeHandlerAsync(
+        SubscriptionRegistration registration,
+        OtelEventContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (registration.LambdaHandler is not null)
+            {
+                await registration.LambdaHandler(context, cancellationToken);
+            }
+            else if (registration.HandlerType is not null)
+            {
+                using var scope = _serviceProvider.CreateScope();
+                var handler = (IOtelEventHandler)scope.ServiceProvider
+                    .GetRequiredService(registration.HandlerType);
+                await handler.HandleAsync(context, cancellationToken);
+            }
+
+            SubscriptionMetrics.EventsDispatched.Add(1);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Graceful shutdown — don't meter this as an error
+            throw;
+        }
+        catch
+        {
+            SubscriptionMetrics.HandlerErrors.Add(1);
+        }
+    }
+}

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionDispatcher.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionDispatcher.cs
@@ -1,6 +1,7 @@
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace OtelEvents.Subscriptions;
 
@@ -13,13 +14,16 @@ internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
 {
     private readonly Channel<DispatchItem> _channel;
     private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<OtelEventsSubscriptionDispatcher> _logger;
 
     public OtelEventsSubscriptionDispatcher(
         Channel<DispatchItem> channel,
-        IServiceProvider serviceProvider)
+        IServiceProvider serviceProvider,
+        ILogger<OtelEventsSubscriptionDispatcher> logger)
     {
         _channel = channel;
         _serviceProvider = serviceProvider;
+        _logger = logger;
     }
 
     /// <inheritdoc/>
@@ -60,8 +64,10 @@ internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
             // Graceful shutdown — don't meter this as an error
             throw;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Subscription handler for pattern '{EventPattern}' failed on event '{EventName}'",
+                registration.EventPattern, context.EventName);
             SubscriptionMetrics.HandlerErrors.Add(1);
         }
     }

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionDispatcher.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionDispatcher.cs
@@ -2,28 +2,33 @@ using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace OtelEvents.Subscriptions;
 
 /// <summary>
 /// Background hosted service that reads from the dispatch channel and invokes
 /// subscription handlers. Each handler invocation is wrapped in try-catch
-/// so handler errors never crash the service.
+/// so handler errors never crash the service. Individual handler calls are
+/// subject to <see cref="OtelEventsSubscriptionOptions.HandlerTimeout"/>.
 /// </summary>
 internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
 {
     private readonly Channel<DispatchItem> _channel;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<OtelEventsSubscriptionDispatcher> _logger;
+    private readonly OtelEventsSubscriptionOptions _options;
 
     public OtelEventsSubscriptionDispatcher(
         Channel<DispatchItem> channel,
         IServiceProvider serviceProvider,
-        ILogger<OtelEventsSubscriptionDispatcher> logger)
+        ILogger<OtelEventsSubscriptionDispatcher> logger,
+        IOptions<OtelEventsSubscriptionOptions> options)
     {
         _channel = channel;
         _serviceProvider = serviceProvider;
         _logger = logger;
+        _options = options.Value;
     }
 
     /// <inheritdoc/>
@@ -33,7 +38,9 @@ internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
         {
             foreach (var registration in item.Registrations)
             {
-                await InvokeHandlerAsync(registration, item.Context, stoppingToken);
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+                timeoutCts.CancelAfter(_options.HandlerTimeout);
+                await InvokeHandlerAsync(registration, item.Context, timeoutCts.Token, stoppingToken);
             }
         }
     }
@@ -41,7 +48,8 @@ internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
     private async Task InvokeHandlerAsync(
         SubscriptionRegistration registration,
         OtelEventContext context,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        CancellationToken stoppingToken)
     {
         try
         {
@@ -59,10 +67,17 @@ internal sealed class OtelEventsSubscriptionDispatcher : BackgroundService
 
             SubscriptionMetrics.EventsDispatched.Add(1);
         }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Graceful shutdown — not a timeout, don't inflate metrics
+        }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // Graceful shutdown — don't meter this as an error
-            throw;
+            // Genuine handler timeout
+            _logger.LogWarning(
+                "Subscription handler for pattern '{EventPattern}' timed out on event '{EventName}'",
+                registration.EventPattern, context.EventName);
+            SubscriptionMetrics.HandlerTimeouts.Add(1);
         }
         catch (Exception ex)
         {

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
@@ -73,6 +74,7 @@ public static class OtelEventsSubscriptionExtensions
             new OtelEventsSubscriptionProcessor(channel, builder.Registrations));
 
         // Register the background dispatch loop
+        services.AddLogging();
         services.AddHostedService<OtelEventsSubscriptionDispatcher>();
 
         return services;

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
@@ -1,6 +1,7 @@
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 
@@ -22,9 +23,13 @@ public static class OtelEventsSubscriptionExtensions
     /// </param>
     /// <param name="configureOptions">
     /// Optional action to configure <see cref="OtelEventsSubscriptionOptions"/>
-    /// (channel capacity, backpressure policy).
+    /// (channel capacity, backpressure policy, handler timeout).
     /// </param>
     /// <returns>The <paramref name="services"/> for chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <see cref="OtelEventsSubscriptionOptions.ChannelCapacity"/> is less than or equal to zero
+    /// or when <see cref="OtelEventsSubscriptionOptions.HandlerTimeout"/> is not positive.
+    /// </exception>
     /// <example>
     /// <code>
     /// builder.Services.AddOtelEventsSubscriptions(
@@ -52,11 +57,22 @@ public static class OtelEventsSubscriptionExtensions
 
         var options = new OtelEventsSubscriptionOptions();
         configureOptions?.Invoke(options);
+        options.Validate();
+
+        // Register options as IOptions<T> for the dispatcher to consume
+        services.Configure<OtelEventsSubscriptionOptions>(opts =>
+        {
+            opts.ChannelCapacity = options.ChannelCapacity;
+            opts.FullMode = options.FullMode;
+            opts.HandlerTimeout = options.HandlerTimeout;
+        });
 
         var builder = new OtelEventsSubscriptionBuilder(services);
         configureSubscriptions?.Invoke(builder);
 
-        // Create the bounded channel with configured capacity and backpressure policy
+        // Create the bounded channel with configured capacity and backpressure policy.
+        // The itemDropped callback fires whenever the channel drops an item in Drop* modes,
+        // ensuring the channel_full counter is accurate regardless of FullMode.
         var channel = Channel.CreateBounded<DispatchItem>(
             new BoundedChannelOptions(options.ChannelCapacity)
             {
@@ -64,7 +80,8 @@ public static class OtelEventsSubscriptionExtensions
                 SingleReader = true,
                 SingleWriter = false,
                 AllowSynchronousContinuations = false,
-            });
+            },
+            itemDropped: _ => SubscriptionMetrics.ChannelFull.Add(1));
 
         // Register the channel as a singleton for processor and dispatcher to share
         services.AddSingleton(channel);

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
@@ -1,0 +1,80 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Extension methods for registering <see cref="OtelEventsSubscriptionProcessor"/>
+/// and the background dispatch loop in the dependency injection container.
+/// </summary>
+public static class OtelEventsSubscriptionExtensions
+{
+    /// <summary>
+    /// Adds the OtelEvents subscription system: a processor that dispatches matching events
+    /// to registered handlers via a background channel.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <param name="configureSubscriptions">
+    /// Optional action to register event subscriptions (lambda and DI-resolved handlers).
+    /// </param>
+    /// <param name="configureOptions">
+    /// Optional action to configure <see cref="OtelEventsSubscriptionOptions"/>
+    /// (channel capacity, backpressure policy).
+    /// </param>
+    /// <returns>The <paramref name="services"/> for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// builder.Services.AddOtelEventsSubscriptions(
+    ///     subs =>
+    ///     {
+    ///         subs.On("cosmosdb.throttled", async (ctx, ct) =>
+    ///         {
+    ///             var retryMs = ctx.GetAttribute&lt;long&gt;("retryAfterMs");
+    ///             await Task.Delay(TimeSpan.FromMilliseconds(retryMs), ct);
+    ///         });
+    ///         subs.AddHandler&lt;OrderPlacedHandler&gt;("order.placed");
+    ///     },
+    ///     opts =>
+    ///     {
+    ///         opts.ChannelCapacity = 2048;
+    ///     });
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddOtelEventsSubscriptions(
+        this IServiceCollection services,
+        Action<OtelEventsSubscriptionBuilder>? configureSubscriptions = null,
+        Action<OtelEventsSubscriptionOptions>? configureOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new OtelEventsSubscriptionOptions();
+        configureOptions?.Invoke(options);
+
+        var builder = new OtelEventsSubscriptionBuilder(services);
+        configureSubscriptions?.Invoke(builder);
+
+        // Create the bounded channel with configured capacity and backpressure policy
+        var channel = Channel.CreateBounded<DispatchItem>(
+            new BoundedChannelOptions(options.ChannelCapacity)
+            {
+                FullMode = options.FullMode,
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false,
+            });
+
+        // Register the channel as a singleton for processor and dispatcher to share
+        services.AddSingleton(channel);
+
+        // Register the processor as a singleton for pipeline registration
+        services.AddSingleton(sp =>
+            new OtelEventsSubscriptionProcessor(channel, builder.Registrations));
+
+        // Register the background dispatch loop
+        services.AddHostedService<OtelEventsSubscriptionDispatcher>();
+
+        return services;
+    }
+}

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionOptions.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionOptions.cs
@@ -11,13 +11,54 @@ public sealed class OtelEventsSubscriptionOptions
     /// <summary>
     /// Gets or sets the bounded channel capacity for event dispatch.
     /// When the channel is full, the <see cref="FullMode"/> policy determines behavior.
+    /// Must be greater than zero.
     /// Default: <c>1024</c>.
     /// </summary>
     public int ChannelCapacity { get; set; } = 1024;
 
     /// <summary>
     /// Gets or sets the backpressure policy when the channel is full.
-    /// Default: <see cref="BoundedChannelFullMode.DropOldest"/>.
+    /// Default: <see cref="BoundedChannelFullMode.DropWrite"/> — events are silently dropped
+    /// and the <c>otel_events.subscription.channel_full</c> counter is incremented.
     /// </summary>
-    public BoundedChannelFullMode FullMode { get; set; } = BoundedChannelFullMode.DropOldest;
+    /// <remarks>
+    /// <see cref="BoundedChannelFullMode.DropOldest"/> causes <c>TryWrite</c> to always
+    /// return <c>true</c>, which prevents the <c>channel_full</c> counter from firing.
+    /// Use <see cref="BoundedChannelFullMode.DropWrite"/> (the default) for accurate metering.
+    /// </remarks>
+    public BoundedChannelFullMode FullMode { get; set; } = BoundedChannelFullMode.DropWrite;
+
+    /// <summary>
+    /// Gets or sets the maximum time allowed for a single handler invocation.
+    /// If a handler does not complete within this timeout, its invocation is cancelled
+    /// and the <c>otel_events.subscription.handler_timeouts</c> counter is incremented.
+    /// Default: <c>30 seconds</c>.
+    /// </summary>
+    public TimeSpan HandlerTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Validates the options and throws if any values are invalid.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <see cref="ChannelCapacity"/> is less than or equal to zero
+    /// or when <see cref="HandlerTimeout"/> is not positive.
+    /// </exception>
+    internal void Validate()
+    {
+        if (ChannelCapacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ChannelCapacity),
+                ChannelCapacity,
+                "Channel capacity must be greater than zero.");
+        }
+
+        if (HandlerTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(HandlerTimeout),
+                HandlerTimeout,
+                "Handler timeout must be a positive duration.");
+        }
+    }
 }

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionOptions.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionOptions.cs
@@ -1,0 +1,23 @@
+using System.Threading.Channels;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Configuration options for <see cref="OtelEventsSubscriptionProcessor"/>
+/// and the background dispatch loop.
+/// </summary>
+public sealed class OtelEventsSubscriptionOptions
+{
+    /// <summary>
+    /// Gets or sets the bounded channel capacity for event dispatch.
+    /// When the channel is full, the <see cref="FullMode"/> policy determines behavior.
+    /// Default: <c>1024</c>.
+    /// </summary>
+    public int ChannelCapacity { get; set; } = 1024;
+
+    /// <summary>
+    /// Gets or sets the backpressure policy when the channel is full.
+    /// Default: <see cref="BoundedChannelFullMode.DropOldest"/>.
+    /// </summary>
+    public BoundedChannelFullMode FullMode { get; set; } = BoundedChannelFullMode.DropOldest;
+}

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionProcessor.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionProcessor.cs
@@ -86,11 +86,11 @@ public sealed class OtelEventsSubscriptionProcessor : BaseProcessor<LogRecord>
         var context = OtelEventContext.FromLogRecord(data);
         var item = new DispatchItem(context, matchingRegistrations);
 
-        // TryWrite is non-blocking — never blocks the OTEL pipeline
-        if (!_channel.Writer.TryWrite(item))
-        {
-            SubscriptionMetrics.ChannelFull.Add(1);
-        }
+        // TryWrite is non-blocking — never blocks the OTEL pipeline.
+        // Drop metering is handled by the channel's itemDropped callback
+        // configured in OtelEventsSubscriptionExtensions, ensuring the
+        // channel_full counter fires for all FullMode policies.
+        _channel.Writer.TryWrite(item);
     }
 
     /// <inheritdoc/>

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionProcessor.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionProcessor.cs
@@ -1,0 +1,154 @@
+using System.Threading.Channels;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// OTEL <see cref="BaseProcessor{T}"/> that snapshots matching log records
+/// and dispatches them to a background <see cref="Channel{T}"/> for handler execution.
+/// <para>
+/// This processor never blocks the OTEL pipeline. Events are matched against
+/// registered subscriptions (exact match first, then wildcards sorted by longest
+/// prefix), snapshotted into <see cref="OtelEventContext"/>, and written to a
+/// bounded channel. A separate <see cref="OtelEventsSubscriptionDispatcher"/>
+/// reads from the channel and invokes handlers.
+/// </para>
+/// </summary>
+public sealed class OtelEventsSubscriptionProcessor : BaseProcessor<LogRecord>
+{
+    private readonly Channel<DispatchItem> _channel;
+    private readonly Dictionary<string, List<SubscriptionRegistration>> _exactSubscriptions;
+    private readonly List<WildcardEntry> _wildcardSubscriptions;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="OtelEventsSubscriptionProcessor"/>.
+    /// </summary>
+    /// <param name="channel">The bounded channel to write dispatch items to.</param>
+    /// <param name="registrations">The subscription registrations from the builder.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="channel"/> or <paramref name="registrations"/> is null.
+    /// </exception>
+    internal OtelEventsSubscriptionProcessor(
+        Channel<DispatchItem> channel,
+        IReadOnlyList<SubscriptionRegistration> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        _channel = channel;
+
+        // Pre-partition registrations into exact and wildcard for fast lookup
+        _exactSubscriptions = [];
+        _wildcardSubscriptions = [];
+
+        foreach (var reg in registrations)
+        {
+            if (reg.IsWildcard)
+            {
+                _wildcardSubscriptions.Add(new WildcardEntry(reg.WildcardPrefix!, reg));
+            }
+            else
+            {
+                if (!_exactSubscriptions.TryGetValue(reg.EventPattern, out var list))
+                {
+                    list = [];
+                    _exactSubscriptions[reg.EventPattern] = list;
+                }
+
+                list.Add(reg);
+            }
+        }
+
+        // Sort wildcards by prefix length descending — longest (most-specific) first
+        _wildcardSubscriptions.Sort((a, b) => b.Prefix.Length.CompareTo(a.Prefix.Length));
+    }
+
+    /// <inheritdoc/>
+    public override void OnEnd(LogRecord data)
+    {
+        var eventName = data.EventId.Name;
+
+        if (string.IsNullOrEmpty(eventName))
+        {
+            return;
+        }
+
+        var matchingRegistrations = GetMatchingRegistrations(eventName);
+
+        if (matchingRegistrations.Count == 0)
+        {
+            return;
+        }
+
+        // Snapshot the LogRecord before it gets recycled by the OTEL pipeline
+        var context = OtelEventContext.FromLogRecord(data);
+        var item = new DispatchItem(context, matchingRegistrations);
+
+        // TryWrite is non-blocking — never blocks the OTEL pipeline
+        if (!_channel.Writer.TryWrite(item))
+        {
+            SubscriptionMetrics.ChannelFull.Add(1);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (!_disposed && disposing)
+        {
+            _disposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Finds all registrations matching the given event name.
+    /// Exact matches are checked first, then wildcards (longest-prefix-first).
+    /// Multiple registrations can match the same event.
+    /// </summary>
+    private List<SubscriptionRegistration> GetMatchingRegistrations(string eventName)
+    {
+        var matches = new List<SubscriptionRegistration>();
+
+        // Exact match (O(1) dictionary lookup)
+        if (_exactSubscriptions.TryGetValue(eventName, out var exactList))
+        {
+            matches.AddRange(exactList);
+        }
+
+        // Wildcard match (prefix-based, sorted longest-first for specificity)
+        foreach (var entry in _wildcardSubscriptions)
+        {
+            if (eventName.StartsWith(entry.Prefix, StringComparison.Ordinal))
+            {
+                matches.Add(entry.Registration);
+            }
+        }
+
+        return matches;
+    }
+
+    /// <summary>
+    /// Pre-sorted wildcard entry for fast prefix matching.
+    /// </summary>
+    private readonly record struct WildcardEntry(string Prefix, SubscriptionRegistration Registration);
+}
+
+/// <summary>
+/// Item placed on the dispatch channel containing the event context
+/// and the list of matching subscription registrations.
+/// </summary>
+internal sealed class DispatchItem
+{
+    public OtelEventContext Context { get; }
+    public IReadOnlyList<SubscriptionRegistration> Registrations { get; }
+
+    public DispatchItem(OtelEventContext context, IReadOnlyList<SubscriptionRegistration> registrations)
+    {
+        Context = context;
+        Registrations = registrations;
+    }
+}

--- a/src/OtelEvents.Subscriptions/SubscriptionMetrics.cs
+++ b/src/OtelEvents.Subscriptions/SubscriptionMetrics.cs
@@ -24,4 +24,9 @@ internal static class SubscriptionMetrics
         Meter.CreateCounter<long>(
             "otel_events.subscription.channel_full",
             description: "Total events dropped or displaced due to channel capacity");
+
+    internal static readonly Counter<long> HandlerTimeouts =
+        Meter.CreateCounter<long>(
+            "otel_events.subscription.handler_timeouts",
+            description: "Total handler invocations cancelled due to timeout");
 }

--- a/src/OtelEvents.Subscriptions/SubscriptionMetrics.cs
+++ b/src/OtelEvents.Subscriptions/SubscriptionMetrics.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Metrics;
+
+namespace OtelEvents.Subscriptions;
+
+/// <summary>
+/// Self-telemetry counters for the subscription processor and dispatch loop.
+/// Uses OTEL's native <see cref="Meter"/> for self-monitoring.
+/// </summary>
+internal static class SubscriptionMetrics
+{
+    internal static readonly Meter Meter = new("otel_events.subscription", "1.0.0");
+
+    internal static readonly Counter<long> EventsDispatched =
+        Meter.CreateCounter<long>(
+            "otel_events.subscription.events_dispatched",
+            description: "Total events dispatched to subscription handlers");
+
+    internal static readonly Counter<long> HandlerErrors =
+        Meter.CreateCounter<long>(
+            "otel_events.subscription.handler_errors",
+            description: "Total errors caught from subscription handlers");
+
+    internal static readonly Counter<long> ChannelFull =
+        Meter.CreateCounter<long>(
+            "otel_events.subscription.channel_full",
+            description: "Total events dropped or displaced due to channel capacity");
+}

--- a/tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj
+++ b/tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CA1031;CA1307;CA1310;CA1515;CA1707;CA1711;CA1848;CA1849;CA1861;CA2000;CA2007;CA2201</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OtelEvents.Subscriptions\OtelEvents.Subscriptions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OtelEvents.Subscriptions.Tests/OtelEventsSubscriptionProcessorTests.cs
+++ b/tests/OtelEvents.Subscriptions.Tests/OtelEventsSubscriptionProcessorTests.cs
@@ -1,0 +1,887 @@
+using System.Diagnostics.Metrics;
+using System.Threading.Channels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using OtelEvents.Subscriptions;
+
+namespace OtelEvents.Subscriptions.Tests;
+
+/// <summary>
+/// Tests for <see cref="OtelEventsSubscriptionProcessor"/> and the subscription dispatch system.
+/// Covers: lambda handlers, DI handlers, wildcard matching, channel backpressure,
+/// handler error isolation, self-telemetry, concurrent dispatch, and disposal.
+/// </summary>
+public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
+{
+    private readonly MeterListener _meterListener = new();
+    private long _eventsDispatched;
+    private long _handlerErrors;
+    private long _channelFull;
+
+    public OtelEventsSubscriptionProcessorTests()
+    {
+        _meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name.StartsWith("otel_events.subscription.", StringComparison.Ordinal))
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        _meterListener.SetMeasurementEventCallback<long>((instrument, measurement, tags, state) =>
+        {
+            switch (instrument.Name)
+            {
+                case "otel_events.subscription.events_dispatched":
+                    Interlocked.Add(ref _eventsDispatched, measurement);
+                    break;
+                case "otel_events.subscription.handler_errors":
+                    Interlocked.Add(ref _handlerErrors, measurement);
+                    break;
+                case "otel_events.subscription.channel_full":
+                    Interlocked.Add(ref _channelFull, measurement);
+                    break;
+            }
+        });
+        _meterListener.Start();
+    }
+
+    public void Dispose()
+    {
+        _meterListener.Dispose();
+    }
+
+    // ─── OtelEventContext ─────────────────────────────────────────────
+
+    [Fact]
+    public void OtelEventContext_FromLogRecord_SnapshotsAllFields()
+    {
+        var record = CreateLogRecord(
+            LogLevel.Warning,
+            eventName: "order.placed",
+            formattedMessage: "Order placed successfully");
+
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Equal("order.placed", context.EventName);
+        Assert.Equal(LogLevel.Warning, context.LogLevel);
+        Assert.Equal("Order placed successfully", context.FormattedMessage);
+        Assert.NotNull(context.Attributes);
+    }
+
+    [Fact]
+    public void OtelEventContext_GetAttribute_ReturnsTypedValue()
+    {
+        var record = CreateLogRecord(eventName: "test.event");
+
+        // Add attributes via reflection
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new("orderId", "abc-123"),
+            new("amount", 42L),
+            new("isUrgent", true),
+        };
+        typeof(LogRecord)
+            .GetProperty(nameof(LogRecord.Attributes))!
+            .SetValue(record, attributes);
+
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Equal("abc-123", context.GetAttribute<string>("orderId"));
+        Assert.Equal(42L, context.GetAttribute<long>("amount"));
+        Assert.True(context.GetAttribute<bool>("isUrgent"));
+    }
+
+    [Fact]
+    public void OtelEventContext_GetAttribute_ReturnsDefault_WhenKeyNotFound()
+    {
+        var record = CreateLogRecord(eventName: "test.event");
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Null(context.GetAttribute<string>("nonexistent"));
+        Assert.Equal(0, context.GetAttribute<int>("nonexistent"));
+    }
+
+    [Fact]
+    public void OtelEventContext_GetAttribute_ReturnsDefault_WhenTypeMismatch()
+    {
+        var record = CreateLogRecord(eventName: "test.event");
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new("value", "not-a-number"),
+        };
+        typeof(LogRecord)
+            .GetProperty(nameof(LogRecord.Attributes))!
+            .SetValue(record, attributes);
+
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Equal(0, context.GetAttribute<int>("value"));
+    }
+
+    [Fact]
+    public void OtelEventContext_NullEventName_DefaultsToEmptyString()
+    {
+        var record = CreateLogRecord(eventName: null);
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Equal(string.Empty, context.EventName);
+    }
+
+    // ─── Lambda handler invocation ───────────────────────────────────
+
+    [Fact]
+    public async Task LambdaHandler_IsInvoked_WhenEventMatches()
+    {
+        var handlerCalled = new TaskCompletionSource<OtelEventContext>();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("order.placed", (ctx, ct) =>
+            {
+                handlerCalled.TrySetResult(ctx);
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "order.placed"));
+
+        var context = await WaitForResult(handlerCalled);
+        Assert.Equal("order.placed", context.EventName);
+    }
+
+    [Fact]
+    public async Task LambdaHandler_NotInvoked_WhenEventDoesNotMatch()
+    {
+        var handlerCalled = false;
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("order.placed", (ctx, ct) =>
+            {
+                handlerCalled = true;
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "order.cancelled"));
+
+        await Task.Delay(100); // give time for potential dispatch
+        Assert.False(handlerCalled);
+    }
+
+    [Fact]
+    public async Task LambdaHandler_ReceivesCorrectContext()
+    {
+        var receivedContext = new TaskCompletionSource<OtelEventContext>();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("test.event", (ctx, ct) =>
+            {
+                receivedContext.TrySetResult(ctx);
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        var record = CreateLogRecord(LogLevel.Error, "test.event", "Something failed");
+        processor.OnEnd(record);
+
+        var ctx = await WaitForResult(receivedContext);
+        Assert.Equal("test.event", ctx.EventName);
+        Assert.Equal(LogLevel.Error, ctx.LogLevel);
+        Assert.Equal("Something failed", ctx.FormattedMessage);
+    }
+
+    // ─── DI-resolved handler invocation ──────────────────────────────
+
+    [Fact]
+    public async Task DiHandler_IsInvoked_WhenEventMatches()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.AddHandler<TestEventHandler>("order.placed");
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "order.placed"));
+
+        await Task.Delay(200); // allow dispatch
+        Assert.True(TestEventHandler.WasCalled);
+        Assert.Equal("order.placed", TestEventHandler.LastContext?.EventName);
+    }
+
+    // ─── Wildcard matching ───────────────────────────────────────────
+
+    [Fact]
+    public async Task WildcardSubscription_MatchesPrefixedEvents()
+    {
+        var matchedEvents = new List<string>();
+        var allDone = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("cosmosdb.*", (ctx, ct) =>
+            {
+                lock (matchedEvents)
+                {
+                    matchedEvents.Add(ctx.EventName);
+                    if (matchedEvents.Count >= 2)
+                    {
+                        allDone.TrySetResult();
+                    }
+                }
+
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "cosmosdb.throttled"));
+        processor.OnEnd(CreateLogRecord(eventName: "cosmosdb.request"));
+        processor.OnEnd(CreateLogRecord(eventName: "other.event")); // should NOT match
+
+        await WaitForResult(allDone);
+        Assert.Equal(2, matchedEvents.Count);
+        Assert.Contains("cosmosdb.throttled", matchedEvents);
+        Assert.Contains("cosmosdb.request", matchedEvents);
+    }
+
+    [Fact]
+    public async Task WildcardSubscription_LongestPrefixWins_BothMatch()
+    {
+        var generalMatched = new List<string>();
+        var specificMatched = new List<string>();
+        var done = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("health.*", (ctx, ct) =>
+            {
+                lock (generalMatched)
+                {
+                    generalMatched.Add(ctx.EventName);
+                }
+
+                return Task.CompletedTask;
+            });
+            subs.On("health.check.*", (ctx, ct) =>
+            {
+                lock (specificMatched)
+                {
+                    specificMatched.Add(ctx.EventName);
+                    if (specificMatched.Count >= 1)
+                    {
+                        done.TrySetResult();
+                    }
+                }
+
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "health.check.executed"));
+
+        await WaitForResult(done);
+        // Wait a bit more for the general handler to also fire
+        await Task.Delay(100);
+
+        // Both should match — general "health.*" and specific "health.check.*"
+        Assert.Contains("health.check.executed", generalMatched);
+        Assert.Contains("health.check.executed", specificMatched);
+    }
+
+    [Fact]
+    public async Task ExactMatch_TakesPrecedence_OverWildcard()
+    {
+        var exactMatched = false;
+        var wildcardMatched = false;
+        var done = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("order.placed", (ctx, ct) =>
+            {
+                exactMatched = true;
+                done.TrySetResult();
+                return Task.CompletedTask;
+            });
+            subs.On("order.*", (ctx, ct) =>
+            {
+                wildcardMatched = true;
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "order.placed"));
+
+        await WaitForResult(done);
+        await Task.Delay(100); // allow time for wildcard handler too
+
+        // Both exact and wildcard should match (they're not exclusive)
+        Assert.True(exactMatched);
+        Assert.True(wildcardMatched);
+    }
+
+    [Fact]
+    public void NullOrEmptyEventName_IsIgnored()
+    {
+        var handlerCalled = false;
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("test.*", (ctx, ct) =>
+            {
+                handlerCalled = true;
+                return Task.CompletedTask;
+            });
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+
+        processor.OnEnd(CreateLogRecord(eventName: null));
+        processor.OnEnd(CreateLogRecord(eventName: ""));
+
+        Assert.False(handlerCalled);
+    }
+
+    // ─── Channel backpressure ────────────────────────────────────────
+
+    [Fact]
+    public void ChannelFull_IncrementsCounter_WhenCapacityExceeded()
+    {
+        // With Wait mode, TryWrite returns false when the channel is full
+        var registrations = new List<SubscriptionRegistration>
+        {
+            new("test.event", (_, _) => Task.CompletedTask),
+        };
+
+        var channel = Channel.CreateBounded<DispatchItem>(
+            new BoundedChannelOptions(2)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+            });
+
+        var processor = new OtelEventsSubscriptionProcessor(channel, registrations);
+
+        // Reset counter baseline
+        var baseline = Interlocked.Read(ref _channelFull);
+
+        // Fill the channel beyond capacity
+        for (var i = 0; i < 5; i++)
+        {
+            processor.OnEnd(CreateLogRecord(eventName: "test.event"));
+        }
+
+        // At least 3 writes should have been rejected (channel capacity is 2)
+        var dropped = Interlocked.Read(ref _channelFull) - baseline;
+        Assert.True(dropped >= 3, $"Expected at least 3 drops but got {dropped}");
+
+        processor.Dispose();
+    }
+
+    [Fact]
+    public async Task ConfigurableChannelCapacity_IsRespected()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(
+            subs => subs.On("test.*", (_, _) => Task.CompletedTask),
+            opts => opts.ChannelCapacity = 16);
+
+        await using var provider = services.BuildServiceProvider();
+        var channel = provider.GetRequiredService<Channel<DispatchItem>>();
+
+        // The channel should be a bounded channel — verify we can write up to capacity
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        for (var i = 0; i < 16; i++)
+        {
+            processor.OnEnd(CreateLogRecord(eventName: "test.event"));
+        }
+
+        // All 16 should fit
+        Assert.Equal(0, Interlocked.Read(ref _channelFull));
+    }
+
+    // ─── Handler error isolation ─────────────────────────────────────
+
+    [Fact]
+    public async Task HandlerError_IsCaught_AndMetered()
+    {
+        var secondHandlerCalled = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("error.event", (ctx, ct) =>
+                throw new InvalidOperationException("handler failure"));
+            subs.On("safe.event", (ctx, ct) =>
+            {
+                secondHandlerCalled.TrySetResult();
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "error.event"));
+        processor.OnEnd(CreateLogRecord(eventName: "safe.event"));
+
+        await WaitForResult(secondHandlerCalled);
+
+        // Error should be metered
+        Assert.True(Interlocked.Read(ref _handlerErrors) > 0);
+        // Safe handler should still have been called (error didn't crash the service)
+    }
+
+    [Fact]
+    public async Task HandlerError_DoesNotCrashDispatcher()
+    {
+        var callCount = 0;
+        var done = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("always.fails", (ctx, ct) =>
+                throw new Exception("boom"));
+            subs.On("after.error", (ctx, ct) =>
+            {
+                Interlocked.Increment(ref callCount);
+                if (callCount >= 3)
+                {
+                    done.TrySetResult();
+                }
+
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        // Send multiple events — errors should not kill the dispatcher
+        for (var i = 0; i < 3; i++)
+        {
+            processor.OnEnd(CreateLogRecord(eventName: "always.fails"));
+            processor.OnEnd(CreateLogRecord(eventName: "after.error"));
+        }
+
+        await WaitForResult(done);
+        Assert.Equal(3, callCount);
+    }
+
+    // ─── Self-telemetry counters ─────────────────────────────────────
+
+    [Fact]
+    public async Task EventsDispatched_Counter_IsIncremented()
+    {
+        var initialDispatched = Interlocked.Read(ref _eventsDispatched);
+        var done = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("metered.event", (ctx, ct) =>
+            {
+                done.TrySetResult();
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "metered.event"));
+
+        await WaitForResult(done);
+        await Task.Delay(50); // allow metric to be recorded
+
+        Assert.True(
+            Interlocked.Read(ref _eventsDispatched) > initialDispatched,
+            "events_dispatched counter should have been incremented");
+    }
+
+    [Fact]
+    public async Task HandlerErrors_Counter_IsIncremented()
+    {
+        var initialErrors = Interlocked.Read(ref _handlerErrors);
+        var followUpDone = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("err.event", (ctx, ct) =>
+                throw new Exception("test error"));
+            subs.On("follow.up", (ctx, ct) =>
+            {
+                followUpDone.TrySetResult();
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "err.event"));
+        processor.OnEnd(CreateLogRecord(eventName: "follow.up"));
+
+        await WaitForResult(followUpDone);
+
+        Assert.True(
+            Interlocked.Read(ref _handlerErrors) > initialErrors,
+            "handler_errors counter should have been incremented");
+    }
+
+    // ─── Concurrent dispatch safety ──────────────────────────────────
+
+    [Fact]
+    public async Task ConcurrentWrites_AreThreadSafe()
+    {
+        var callCount = 0;
+        var done = new TaskCompletionSource();
+        const int totalEvents = 100;
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(
+            subs =>
+            {
+                subs.On("concurrent.event", (ctx, ct) =>
+                {
+                    if (Interlocked.Increment(ref callCount) >= totalEvents)
+                    {
+                        done.TrySetResult();
+                    }
+
+                    return Task.CompletedTask;
+                });
+            },
+            opts => opts.ChannelCapacity = totalEvents + 10);
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        // Write from multiple threads concurrently
+        var tasks = Enumerable.Range(0, totalEvents)
+            .Select(_ => Task.Run(() =>
+                processor.OnEnd(CreateLogRecord(eventName: "concurrent.event"))))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+        await WaitForResult(done);
+
+        Assert.Equal(totalEvents, callCount);
+    }
+
+    // ─── Disposal/shutdown ───────────────────────────────────────────
+
+    [Fact]
+    public void Processor_CanBeDisposed_Safely()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("test.event", (_, _) => Task.CompletedTask);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+
+        processor.Dispose();
+        processor.Dispose(); // double dispose should not throw
+    }
+
+    [Fact]
+    public async Task Dispatcher_ShutdownGracefully_WhenCancelled()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("test.event", (_, _) => Task.CompletedTask);
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        using var cts = new CancellationTokenSource();
+
+        var hostedServices = provider.GetServices<IHostedService>();
+        var dispatcher = hostedServices.OfType<OtelEventsSubscriptionDispatcher>().Single();
+
+        // Start and then cancel
+        await dispatcher.StartAsync(cts.Token);
+        cts.Cancel();
+        await dispatcher.StopAsync(CancellationToken.None);
+
+        // Should complete without throwing
+    }
+
+    // ─── Builder validation ──────────────────────────────────────────
+
+    [Fact]
+    public void Builder_On_NullOrEmptyPattern_Throws()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.On("", (_, _) => Task.CompletedTask));
+        Assert.Throws<ArgumentException>(() =>
+            builder.On(null!, (_, _) => Task.CompletedTask));
+    }
+
+    [Fact]
+    public void Builder_On_BareWildcard_Throws()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.On("*", (_, _) => Task.CompletedTask));
+    }
+
+    [Fact]
+    public void Builder_On_NullHandler_Throws()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        Assert.Throws<ArgumentNullException>(() =>
+            builder.On("test.event", null!));
+    }
+
+    [Fact]
+    public void Builder_AddHandler_NullOrEmptyPattern_Throws()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.AddHandler<TestEventHandler>(""));
+        Assert.Throws<ArgumentException>(() =>
+            builder.AddHandler<TestEventHandler>(null!));
+    }
+
+    [Fact]
+    public void Builder_AddHandler_BareWildcard_Throws()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.AddHandler<TestEventHandler>("*"));
+    }
+
+    // ─── DI extension validation ─────────────────────────────────────
+
+    [Fact]
+    public void AddOtelEventsSubscriptions_NullServices_Throws()
+    {
+        IServiceCollection? services = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            services!.AddOtelEventsSubscriptions());
+    }
+
+    [Fact]
+    public void AddOtelEventsSubscriptions_NoCallbacks_RegistersServices()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions();
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<OtelEventsSubscriptionProcessor>());
+        Assert.NotNull(provider.GetService<Channel<DispatchItem>>());
+    }
+
+    // ─── Options defaults ────────────────────────────────────────────
+
+    [Fact]
+    public void DefaultOptions_ChannelCapacityIs1024()
+    {
+        var options = new OtelEventsSubscriptionOptions();
+
+        Assert.Equal(1024, options.ChannelCapacity);
+    }
+
+    [Fact]
+    public void DefaultOptions_FullModeIsDropOldest()
+    {
+        var options = new OtelEventsSubscriptionOptions();
+
+        Assert.Equal(BoundedChannelFullMode.DropOldest, options.FullMode);
+    }
+
+    // ─── Multiple subscriptions for same event ───────────────────────
+
+    [Fact]
+    public async Task MultipleHandlers_ForSameEvent_AllAreInvoked()
+    {
+        var handler1Called = false;
+        var handler2Called = false;
+        var done = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("multi.event", (ctx, ct) =>
+            {
+                handler1Called = true;
+                return Task.CompletedTask;
+            });
+            subs.On("multi.event", (ctx, ct) =>
+            {
+                handler2Called = true;
+                done.TrySetResult();
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "multi.event"));
+
+        await WaitForResult(done);
+        await Task.Delay(50);
+
+        Assert.True(handler1Called);
+        Assert.True(handler2Called);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates a <see cref="LogRecord"/> using reflection (internal constructor).
+    /// Follows the same pattern used in the project's existing test infrastructure.
+    /// </summary>
+    private static LogRecord CreateLogRecord(
+        LogLevel logLevel = LogLevel.Information,
+        string? eventName = null,
+        string? formattedMessage = null)
+    {
+        var record = (LogRecord)Activator.CreateInstance(typeof(LogRecord), nonPublic: true)!;
+        record.LogLevel = logLevel;
+
+        if (eventName is not null)
+        {
+            record.EventId = new EventId(0, eventName);
+        }
+
+        if (formattedMessage is not null)
+        {
+            record.FormattedMessage = formattedMessage;
+        }
+
+        return record;
+    }
+
+    /// <summary>
+    /// Starts the dispatcher (hosted service) from the service provider.
+    /// </summary>
+    private static async Task StartDispatcher(ServiceProvider provider)
+    {
+        var hostedServices = provider.GetServices<IHostedService>();
+        foreach (var service in hostedServices)
+        {
+            await service.StartAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// Waits for a TaskCompletionSource with timeout to avoid test hangs.
+    /// </summary>
+    private static async Task<T> WaitForResult<T>(TaskCompletionSource<T> tcs)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var registration = cts.Token.Register(() =>
+            tcs.TrySetException(new TimeoutException("Test timed out waiting for handler")));
+
+        try
+        {
+            return await tcs.Task;
+        }
+        finally
+        {
+            await registration.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Waits for a TaskCompletionSource with timeout.
+    /// </summary>
+    private static async Task WaitForResult(TaskCompletionSource tcs)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var registration = cts.Token.Register(() =>
+            tcs.TrySetException(new TimeoutException("Test timed out waiting for handler")));
+
+        try
+        {
+            await tcs.Task;
+        }
+        finally
+        {
+            await registration.DisposeAsync();
+        }
+    }
+}
+
+/// <summary>
+/// Test handler for DI-resolved handler tests.
+/// Uses static state because DI creates new instances.
+/// </summary>
+public sealed class TestEventHandler : IOtelEventHandler
+{
+    public static bool WasCalled { get; set; }
+    public static OtelEventContext? LastContext { get; set; }
+
+    public Task HandleAsync(OtelEventContext context, CancellationToken cancellationToken)
+    {
+        WasCalled = true;
+        LastContext = context;
+        return Task.CompletedTask;
+    }
+}

--- a/tests/OtelEvents.Subscriptions.Tests/OtelEventsSubscriptionProcessorTests.cs
+++ b/tests/OtelEvents.Subscriptions.Tests/OtelEventsSubscriptionProcessorTests.cs
@@ -11,7 +11,8 @@ namespace OtelEvents.Subscriptions.Tests;
 /// <summary>
 /// Tests for <see cref="OtelEventsSubscriptionProcessor"/> and the subscription dispatch system.
 /// Covers: lambda handlers, DI handlers, wildcard matching, channel backpressure,
-/// handler error isolation, self-telemetry, concurrent dispatch, and disposal.
+/// handler error isolation, self-telemetry, concurrent dispatch, disposal,
+/// disposable subscriptions, handler timeout, and snapshot integrity.
 /// </summary>
 public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
 {
@@ -19,6 +20,7 @@ public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
     private long _eventsDispatched;
     private long _handlerErrors;
     private long _channelFull;
+    private long _handlerTimeouts;
 
     public OtelEventsSubscriptionProcessorTests()
     {
@@ -41,6 +43,9 @@ public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
                     break;
                 case "otel_events.subscription.channel_full":
                     Interlocked.Add(ref _channelFull, measurement);
+                    break;
+                case "otel_events.subscription.handler_timeouts":
+                    Interlocked.Add(ref _handlerTimeouts, measurement);
                     break;
             }
         });
@@ -386,35 +391,28 @@ public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
     [Fact]
     public void ChannelFull_IncrementsCounter_WhenCapacityExceeded()
     {
-        // With Wait mode, TryWrite returns false when the channel is full
-        var registrations = new List<SubscriptionRegistration>
-        {
-            new("test.event", (_, _) => Task.CompletedTask),
-        };
+        // Uses full DI setup so the itemDropped callback is wired up,
+        // ensuring the counter fires regardless of FullMode.
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(
+            subs => subs.On("test.event", (_, _) => Task.CompletedTask),
+            opts => opts.ChannelCapacity = 2);
 
-        var channel = Channel.CreateBounded<DispatchItem>(
-            new BoundedChannelOptions(2)
-            {
-                FullMode = BoundedChannelFullMode.Wait,
-                SingleReader = true,
-            });
-
-        var processor = new OtelEventsSubscriptionProcessor(channel, registrations);
+        using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
 
         // Reset counter baseline
         var baseline = Interlocked.Read(ref _channelFull);
 
-        // Fill the channel beyond capacity
+        // Fill the channel beyond capacity (don't start dispatcher so items pile up)
         for (var i = 0; i < 5; i++)
         {
             processor.OnEnd(CreateLogRecord(eventName: "test.event"));
         }
 
-        // At least 3 writes should have been rejected (channel capacity is 2)
+        // At least 3 writes should have been dropped (channel capacity is 2)
         var dropped = Interlocked.Read(ref _channelFull) - baseline;
         Assert.True(dropped >= 3, $"Expected at least 3 drops but got {dropped}");
-
-        processor.Dispose();
     }
 
     [Fact]
@@ -746,11 +744,11 @@ public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
     }
 
     [Fact]
-    public void DefaultOptions_FullModeIsDropOldest()
+    public void DefaultOptions_FullModeIsDropWrite()
     {
         var options = new OtelEventsSubscriptionOptions();
 
-        Assert.Equal(BoundedChannelFullMode.DropOldest, options.FullMode);
+        Assert.Equal(BoundedChannelFullMode.DropWrite, options.FullMode);
     }
 
     // ─── Multiple subscriptions for same event ───────────────────────
@@ -789,6 +787,393 @@ public sealed class OtelEventsSubscriptionProcessorTests : IDisposable
 
         Assert.True(handler1Called);
         Assert.True(handler2Called);
+    }
+
+    // ─── Wildcard dot-boundary (Fix #5) ──────────────────────────────
+
+    [Fact]
+    public async Task WildcardSubscription_RequiresDotBoundary()
+    {
+        // "cosmosdb.*" should match "cosmosdb.throttled" but NOT "cosmosdbx.throttled"
+        var matchedEvents = new List<string>();
+        var done = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("cosmosdb.*", (ctx, ct) =>
+            {
+                lock (matchedEvents)
+                {
+                    matchedEvents.Add(ctx.EventName);
+                    if (matchedEvents.Count >= 1)
+                    {
+                        done.TrySetResult();
+                    }
+                }
+
+                return Task.CompletedTask;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "cosmosdb.throttled")); // should match
+        processor.OnEnd(CreateLogRecord(eventName: "cosmosdbx.throttled")); // should NOT match
+
+        await WaitForResult(done);
+        await Task.Delay(100); // allow time for potential false match
+
+        Assert.Single(matchedEvents);
+        Assert.Contains("cosmosdb.throttled", matchedEvents);
+        Assert.DoesNotContain("cosmosdbx.throttled", matchedEvents);
+    }
+
+    // ─── Background dispatch proof (Fix #6) ──────────────────────────
+
+    [Fact]
+    public async Task OnEnd_ReturnsBeforeHandlerExecutes()
+    {
+        // Proves that OnEnd is non-blocking: the handler runs in the background
+        var handlerStarted = new TaskCompletionSource();
+        var handlerFinished = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("async.event", async (ctx, ct) =>
+            {
+                handlerStarted.TrySetResult();
+                await Task.Delay(200, ct);
+                handlerFinished.TrySetResult();
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        // OnEnd should return immediately — before the handler starts
+        processor.OnEnd(CreateLogRecord(eventName: "async.event"));
+        Assert.False(handlerFinished.Task.IsCompleted, "Handler should not have finished yet");
+
+        // But eventually the handler completes via background dispatch
+        await WaitForResult(handlerStarted);
+        await WaitForResult(handlerFinished);
+    }
+
+    // ─── OtelEventContext snapshot completeness (Fix #6) ─────────────
+
+    [Fact]
+    public void OtelEventContext_FromLogRecord_CapturesTimestampTraceIdSpanIdException()
+    {
+        var record = CreateLogRecord(
+            LogLevel.Error,
+            eventName: "full.snapshot",
+            formattedMessage: "Snapshot test");
+
+        // Set exception via reflection
+        var exception = new InvalidOperationException("test exception");
+        typeof(LogRecord)
+            .GetProperty(nameof(LogRecord.Exception))!
+            .SetValue(record, exception);
+
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Equal("full.snapshot", context.EventName);
+        Assert.Equal(LogLevel.Error, context.LogLevel);
+        Assert.Equal("Snapshot test", context.FormattedMessage);
+        Assert.NotEqual(default, context.Timestamp);
+        Assert.Same(exception, context.Exception);
+        // TraceId and SpanId default to null when not set on LogRecord
+    }
+
+    [Fact]
+    public void OtelEventContext_FromLogRecord_DeepCopiesArrayAttributes()
+    {
+        var originalArray = new[] { 1, 2, 3 };
+        var record = CreateLogRecord(eventName: "array.test");
+        var attributes = new List<KeyValuePair<string, object?>>
+        {
+            new("numbers", originalArray),
+            new("scalar", 42L),
+        };
+        typeof(LogRecord)
+            .GetProperty(nameof(LogRecord.Attributes))!
+            .SetValue(record, attributes);
+
+        var context = OtelEventContext.FromLogRecord(record);
+
+        // The array should be a deep copy, not the same reference
+        var snapshotArray = context.GetAttribute<int[]>("numbers");
+        Assert.NotNull(snapshotArray);
+        Assert.Equal(originalArray, snapshotArray);
+        Assert.NotSame(originalArray, snapshotArray);
+
+        // Mutating the original should not affect the snapshot
+        originalArray[0] = 999;
+        Assert.Equal(1, snapshotArray![0]);
+    }
+
+    // ─── DI resolution failure isolation (Fix #6) ────────────────────
+
+    [Fact]
+    public async Task DiResolutionFailure_IsIsolated_DoesNotCrashDispatcher()
+    {
+        var followUpDone = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            // Register a handler type that has unresolvable dependencies
+            subs.AddHandler<UnresolvableHandler>("fail.di");
+            subs.On("after.di.failure", (ctx, ct) =>
+            {
+                followUpDone.TrySetResult();
+                return Task.CompletedTask;
+            });
+        });
+
+        // Remove the auto-registered transient so DI resolution fails
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(UnresolvableHandler));
+        if (descriptor is not null)
+        {
+            services.Remove(descriptor);
+        }
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "fail.di"));
+        processor.OnEnd(CreateLogRecord(eventName: "after.di.failure"));
+
+        // The dispatcher should survive the DI failure and process the next event
+        await WaitForResult(followUpDone);
+        Assert.True(Interlocked.Read(ref _handlerErrors) > 0);
+    }
+
+    // ─── OperationCanceledException during normal operation (Fix #6) ─
+
+    [Fact]
+    public async Task OperationCanceledException_DuringHandler_IsTreatedAsTimeout()
+    {
+        var baselineTimeouts = Interlocked.Read(ref _handlerTimeouts);
+        var followUpDone = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(
+            subs =>
+            {
+                subs.On("timeout.event", async (ctx, ct) =>
+                {
+                    // Simulate a handler that exceeds its timeout
+                    await Task.Delay(TimeSpan.FromSeconds(10), ct);
+                });
+                subs.On("after.timeout", (ctx, ct) =>
+                {
+                    followUpDone.TrySetResult();
+                    return Task.CompletedTask;
+                });
+            },
+            opts =>
+            {
+                opts.HandlerTimeout = TimeSpan.FromMilliseconds(50);
+            });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "timeout.event"));
+        processor.OnEnd(CreateLogRecord(eventName: "after.timeout"));
+
+        await WaitForResult(followUpDone);
+
+        var timeouts = Interlocked.Read(ref _handlerTimeouts) - baselineTimeouts;
+        Assert.True(timeouts >= 1, $"Expected at least 1 handler timeout but got {timeouts}");
+    }
+
+    // ─── Post-dispose behavior (Fix #6) ──────────────────────────────
+
+    [Fact]
+    public void Processor_PostDispose_OnEndIsNoop()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(subs =>
+        {
+            subs.On("post.dispose", (_, _) => Task.CompletedTask);
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+
+        processor.Dispose();
+
+        // OnEnd after dispose should not throw
+        var exception = Record.Exception(() =>
+            processor.OnEnd(CreateLogRecord(eventName: "post.dispose")));
+        Assert.Null(exception);
+    }
+
+    // ─── GetAttribute<T>(null) handling (Fix #6) ─────────────────────
+
+    [Fact]
+    public void OtelEventContext_GetAttribute_NullKey_ReturnsDefault()
+    {
+        var record = CreateLogRecord(eventName: "null.key.test");
+        var context = OtelEventContext.FromLogRecord(record);
+
+        Assert.Null(context.GetAttribute<string>(null));
+        Assert.Equal(0, context.GetAttribute<int>(null));
+    }
+
+    // ─── Disposable subscriptions (Fix #4 — AC-9) ────────────────────
+
+    [Fact]
+    public void On_ReturnsDisposable()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        var subscription = builder.On("test.event", (_, _) => Task.CompletedTask);
+
+        Assert.NotNull(subscription);
+        Assert.IsAssignableFrom<IDisposable>(subscription);
+    }
+
+    [Fact]
+    public void AddHandler_ReturnsDisposable()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        var subscription = builder.AddHandler<TestEventHandler>("test.event");
+
+        Assert.NotNull(subscription);
+        Assert.IsAssignableFrom<IDisposable>(subscription);
+    }
+
+    [Fact]
+    public void DisposableSubscription_RemovesRegistration_WhenDisposed()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        var sub1 = builder.On("event.a", (_, _) => Task.CompletedTask);
+        builder.On("event.b", (_, _) => Task.CompletedTask);
+
+        Assert.Equal(2, builder.Registrations.Count);
+
+        sub1.Dispose();
+
+        Assert.Single(builder.Registrations);
+        Assert.Equal("event.b", builder.Registrations[0].EventPattern);
+    }
+
+    [Fact]
+    public void DisposableSubscription_DoubleDispose_IsNoop()
+    {
+        var services = new ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+
+        var sub = builder.On("event.a", (_, _) => Task.CompletedTask);
+        builder.On("event.b", (_, _) => Task.CompletedTask);
+
+        sub.Dispose();
+        sub.Dispose(); // second dispose should be a no-op
+
+        Assert.Single(builder.Registrations);
+    }
+
+    // ─── ChannelCapacity validation (Fix #7) ─────────────────────────
+
+    [Fact]
+    public void Options_ZeroCapacity_Throws()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddOtelEventsSubscriptions(configureOptions: opts => opts.ChannelCapacity = 0));
+    }
+
+    [Fact]
+    public void Options_NegativeCapacity_Throws()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddOtelEventsSubscriptions(configureOptions: opts => opts.ChannelCapacity = -1));
+    }
+
+    [Fact]
+    public void Options_ZeroHandlerTimeout_Throws()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddOtelEventsSubscriptions(configureOptions: opts => opts.HandlerTimeout = TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void Options_NegativeHandlerTimeout_Throws()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddOtelEventsSubscriptions(configureOptions: opts => opts.HandlerTimeout = TimeSpan.FromSeconds(-1)));
+    }
+
+    // ─── Handler timeout behavior (Fix #2) ───────────────────────────
+
+    [Fact]
+    public void DefaultOptions_HandlerTimeoutIs30Seconds()
+    {
+        var options = new OtelEventsSubscriptionOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(30), options.HandlerTimeout);
+    }
+
+    [Fact]
+    public async Task HandlerTimeout_CancelsHungHandler_AndContinuesDispatch()
+    {
+        var baselineTimeouts = Interlocked.Read(ref _handlerTimeouts);
+        var followUpDone = new TaskCompletionSource();
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsSubscriptions(
+            subs =>
+            {
+                subs.On("hung.handler", async (ctx, ct) =>
+                {
+                    // This handler will hang until cancelled by timeout
+                    await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+                });
+                subs.On("after.hung", (ctx, ct) =>
+                {
+                    followUpDone.TrySetResult();
+                    return Task.CompletedTask;
+                });
+            },
+            opts =>
+            {
+                opts.HandlerTimeout = TimeSpan.FromMilliseconds(100);
+            });
+
+        await using var provider = services.BuildServiceProvider();
+        var processor = provider.GetRequiredService<OtelEventsSubscriptionProcessor>();
+        await StartDispatcher(provider);
+
+        processor.OnEnd(CreateLogRecord(eventName: "hung.handler"));
+        processor.OnEnd(CreateLogRecord(eventName: "after.hung"));
+
+        // The follow-up handler should still execute after the timeout
+        await WaitForResult(followUpDone);
+
+        var timeouts = Interlocked.Read(ref _handlerTimeouts) - baselineTimeouts;
+        Assert.True(timeouts >= 1, $"Expected at least 1 handler timeout but got {timeouts}");
     }
 
     // ─── Helpers ─────────────────────────────────────────────────────
@@ -882,6 +1267,23 @@ public sealed class TestEventHandler : IOtelEventHandler
     {
         WasCalled = true;
         LastContext = context;
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Test handler with an unresolvable dependency for DI failure isolation tests.
+/// </summary>
+public sealed class UnresolvableHandler : IOtelEventHandler
+{
+    // Constructor requires a dependency that won't be in DI
+    public UnresolvableHandler(IServiceProvider _)
+    {
+        throw new InvalidOperationException("This handler cannot be constructed");
+    }
+
+    public Task HandleAsync(OtelEventContext context, CancellationToken cancellationToken)
+    {
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
New package `OtelEvents.Subscriptions` — subscribe to and react to events in-process.

### API
```csharp
builder.Services.AddOtelEventsSubscriptions(subs =>
{
    subs.On("cosmosdb.throttled", async (ctx, ct) =>
        await circuitBreaker.Trip(TimeSpan.FromMilliseconds(ctx.GetAttribute<long>("retryAfterMs"))));
    subs.On("*.auth.failed", (ctx, ct) => { tokenRefresher.ForceRefresh(); return Task.CompletedTask; });
    subs.AddHandler<OrderPlacedHandler>("order.placed");
});
```

### Architecture
- **OtelEventsSubscriptionProcessor**: BaseProcessor dispatching to Channel
- **Background dispatch**: Channel<OtelEventContext> → BackgroundService loop
- **Error isolation**: Handler failures caught + metered, never crash pipeline
- **Wildcard matching**: Longest-prefix-first (reuses existing pattern)
- **Self-telemetry**: events_dispatched, handler_errors, channel_full counters

### Tests: 32 (handlers, wildcards, backpressure, error isolation, DI, shutdown)

Closes #11