### PR TITLE
ci: Add vulnerability scanning, symbol packages, coverage (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,21 @@ jobs:
       - name: Build
         run: dotnet build --no-restore -c Release
 
-      - name: Test
-        run: dotnet test --no-build -c Release --verbosity minimal
+      - name: Test with coverage
+        run: dotnet test --no-build -c Release --verbosity minimal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Check for vulnerable packages
+        run: |
+          dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerability-report.txt
+          if grep -q "has the following vulnerable packages" vulnerability-report.txt; then
+            echo "::error::Vulnerable NuGet packages detected. See output above."
+            exit 1
+          fi
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports-${{ matrix.dotnet-version }}
+          path: ./coverage/**/coverage.cobertura.xml
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,26 +30,40 @@ jobs:
       - name: Test
         run: dotnet test --no-build -c Release --verbosity minimal
 
+      - name: Check for vulnerable packages
+        run: |
+          dotnet list package --vulnerable --include-transitive 2>&1 | tee vulnerability-report.txt
+          if grep -q "has the following vulnerable packages" vulnerability-report.txt; then
+            echo "::error::Vulnerable NuGet packages detected. Aborting release."
+            exit 1
+          fi
+
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
-      - name: Pack NuGet packages
+      - name: Pack NuGet packages with symbols
         run: |
-          dotnet pack src/OtelEvents.Schema/OtelEvents.Schema.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Exporter.Json/OtelEvents.Exporter.Json.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Causality/OtelEvents.Causality.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Analyzers/OtelEvents.Analyzers.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Testing/OtelEvents.Testing.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.AspNetCore/OtelEvents.AspNetCore.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Grpc/OtelEvents.Grpc.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Azure.CosmosDb/OtelEvents.Azure.CosmosDb.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.Azure.Storage/OtelEvents.Azure.Storage.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack src/OtelEvents.HealthChecks/OtelEvents.HealthChecks.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
-          dotnet pack tools/OtelEvents.Cli/OtelEvents.Cli.csproj -c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }}
+          PACK_OPTS="-c Release -o ./nupkgs /p:Version=${{ steps.version.outputs.VERSION }} /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg"
+          dotnet pack src/OtelEvents.Schema/OtelEvents.Schema.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Exporter.Json/OtelEvents.Exporter.Json.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Causality/OtelEvents.Causality.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Analyzers/OtelEvents.Analyzers.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Testing/OtelEvents.Testing.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.AspNetCore/OtelEvents.AspNetCore.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Grpc/OtelEvents.Grpc.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Azure.CosmosDb/OtelEvents.Azure.CosmosDb.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.Azure.Storage/OtelEvents.Azure.Storage.csproj $PACK_OPTS
+          dotnet pack src/OtelEvents.HealthChecks/OtelEvents.HealthChecks.csproj $PACK_OPTS
+          dotnet pack tools/OtelEvents.Cli/OtelEvents.Cli.csproj $PACK_OPTS
+
+      # TODO: Add NuGet package signing (dotnet nuget sign) when a code-signing
+      # certificate is available. See https://learn.microsoft.com/nuget/create-packages/sign-a-package
 
       - name: Push to NuGet.org
-        run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: |
+          dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push ./nupkgs/*.snupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         if: ${{ secrets.NUGET_API_KEY != '' }} != ''
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
@@ -58,4 +72,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: ./nupkgs/*.nupkg
+          files: |
+            ./nupkgs/*.nupkg
+            ./nupkgs/*.snupkg


### PR DESCRIPTION
- dotnet list package --vulnerable in CI
- Test coverage collection (XPlat Code Coverage)
- Symbol packages (.snupkg) in release
- Vulnerability check before NuGet push
Closes #16