### PR TITLE
docs: Fix deployment manifests — CA cert, topology, Service, spec (#17)

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -2385,6 +2385,10 @@ receivers:
           cert_file: /etc/otel/certs/tls.crt
           key_file: /etc/otel/certs/tls.key
 
+extensions:
+  file_storage:
+    directory: /var/lib/otelcol/file_storage
+
 processors:
   batch:
     timeout: 5s
@@ -2400,10 +2404,12 @@ exporters:
     tls:
       insecure: false
       ca_file: /etc/otel/certs/ca.crt
+  # NOTE: In-cluster traffic. For mTLS, use a service mesh or switch to https://
   loki:
     endpoint: "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
 
 service:
+  extensions: [file_storage]
   pipelines:
     logs:
       receivers: [filelog]

--- a/docs/deployment/k8s/deployment.yaml
+++ b/docs/deployment/k8s/deployment.yaml
@@ -74,6 +74,10 @@ spec:
             - name: otel-certs
               mountPath: /etc/otel/certs
               readOnly: true
+            - name: otel-ca-cert
+              mountPath: /etc/otel/certs/ca.crt
+              subPath: ca.crt
+              readOnly: true
             - name: tmp
               mountPath: /tmp
           livenessProbe:
@@ -99,8 +103,18 @@ spec:
         - name: otel-certs
           secret:
             secretName: otel-tls-certs
+        - name: otel-ca-cert
+          configMap:
+            name: otel-ca-cert
         - name: tmp
           emptyDir:
             sizeLimit: 100Mi
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: my-service
       terminationGracePeriodSeconds: 30
       automountServiceAccountToken: false

--- a/docs/deployment/k8s/service.yaml
+++ b/docs/deployment/k8s/service.yaml
@@ -1,0 +1,20 @@
+# Kubernetes Service manifest for .NET services using otel-events.
+#
+# Exposes the application within the cluster on port 80,
+# routing traffic to container port 8080.
+#
+# Customize: Replace "my-service" with your service name.
+#
+# See: SPECIFICATION.md §17.4
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: production
+spec:
+  selector:
+    app: my-service
+  ports:
+    - port: 80
+      targetPort: 8080
+  type: ClusterIP

--- a/docs/deployment/otel-collector-config.yaml
+++ b/docs/deployment/otel-collector-config.yaml
@@ -46,3 +46,46 @@ receivers:
     include_file_path: true
     storage: file_storage
 
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        tls:
+          cert_file: /etc/otel/certs/tls.crt
+          key_file: /etc/otel/certs/tls.key
+      http:
+        endpoint: 0.0.0.0:4318
+        tls:
+          cert_file: /etc/otel/certs/tls.crt
+          key_file: /etc/otel/certs/tls.key
+
+extensions:
+  file_storage:
+    directory: /var/lib/otelcol/file_storage
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1000
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 512
+    spike_limit_mib: 128
+
+exporters:
+  otlp:
+    endpoint: "otel-gateway.monitoring.svc.cluster.local:4317"
+    tls:
+      insecure: false
+      ca_file: /etc/otel/certs/ca.crt
+  # NOTE: In-cluster traffic. For mTLS, use a service mesh or switch to https://
+  loki:
+    endpoint: "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+
+service:
+  extensions: [file_storage]
+  pipelines:
+    logs:
+      receivers: [filelog]
+      processors: [memory_limiter, batch]
+      exporters: [otlp, loki]


### PR DESCRIPTION
- Mount otel-ca-cert ConfigMap in deployment.yaml
- Add topologySpreadConstraints
- Add k8s/service.yaml
- Add TLS comment on Loki exporter
- Fix SPECIFICATION.md §17.1 file_storage extension
Closes #17