### PR TITLE
chore: Add global.json for SDK pinning, delete old v0.1.0 tag (#24, #26)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.102",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
- global.json pinning .NET 10 SDK with rollForward: latestFeature
- Deleted stale v0.1.0 tag (will re-tag after all fixes merge)
Closes #24 Closes #26