### PR TITLE
chore: Add NuGet package metadata — README, descriptions, license, tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-11
+
+### Fixed
+
+- NuGet package metadata (README, description, license, tags)
+- All user guide chapters reviewed and corrected
+- Deployment docs fixes (HEALTHCHECK, SDK version, Collector config)
+- CI hardening (vulnerability scanning, coverage, symbol packages)
+- MSBuild auto-codegen (schemas generate on build)
+
+### Added
+
+- CHANGELOG.md and CONTRIBUTING.md
+- global.json for SDK pinning
+- SLI/SLO recommendation docs
+
 ## [0.1.0] - 2026-03-11
 
 ### Added
@@ -89,5 +105,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ~1,500 unit tests across 12 test projects using xUnit, covering all packages,
   edge cases, and error paths.
 
-[unreleased]: https://github.com/vbomfim/otel-events-dotnet/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/vbomfim/otel-events-dotnet/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/vbomfim/otel-events-dotnet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/vbomfim/otel-events-dotnet/releases/tag/v0.1.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,17 @@
     <AnalysisLevel>latest-all</AnalysisLevel>
     <NoWarn>CA1873</NoWarn>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- NuGet package metadata -->
+    <Authors>Bomfim</Authors>
+    <Company>otel-events</Company>
+    <PackageProjectUrl>https://github.com/vbomfim/otel-events-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/vbomfim/otel-events-dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>opentelemetry;otel;logging;events;observability;dotnet;structured-logging</PackageTags>
+    <Copyright>Copyright (c) 2026 Bomfim</Copyright>
+  </PropertyGroup>
 </Project>

--- a/src/OtelEvents.Analyzers/OtelEvents.Analyzers.csproj
+++ b/src/OtelEvents.Analyzers/OtelEvents.Analyzers.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <Description>Roslyn analyzers for logging hygiene — detects Console.Write, untyped ILogger, string interpolation, PII without redaction</Description>
     <NoWarn>CA1062;CA1303;CA1307;CA1310;CA1707;CA1822</NoWarn>
   </PropertyGroup>
 
@@ -20,6 +21,10 @@
   <ItemGroup>
     <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
     <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.AspNetCore/OtelEvents.AspNetCore.csproj
+++ b/src/OtelEvents.AspNetCore/OtelEvents.AspNetCore.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Zero-code HTTP request instrumentation for ASP.NET Core with connection, auth, and throttle events</Description>
     <NoWarn>CA1031;CA1062;CA1308;CA1822;CA2000;CA2007;CA2227;SYSLIB1015</NoWarn>
   </PropertyGroup>
 
@@ -24,6 +25,10 @@
     <EmbeddedResource Include="Schemas\aspnetcore.otel.yaml">
       <LogicalName>OtelEvents.AspNetCore.aspnetcore.otel.yaml</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Azure.CosmosDb/OtelEvents.Azure.CosmosDb.csproj
+++ b/src/OtelEvents.Azure.CosmosDb/OtelEvents.Azure.CosmosDb.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Zero-code Azure CosmosDB instrumentation with RU tracking, auth, and throttle events</Description>
     <NoWarn>CA1031;CA1062;CA1822;CA2000;SYSLIB1015</NoWarn>
   </PropertyGroup>
 
@@ -21,6 +22,10 @@
     <EmbeddedResource Include="Schemas\cosmosdb.otel.yaml">
       <LogicalName>OtelEvents.Azure.CosmosDb.cosmosdb.otel.yaml</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Azure.Storage/OtelEvents.Azure.Storage.csproj
+++ b/src/OtelEvents.Azure.Storage/OtelEvents.Azure.Storage.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Zero-code Azure Blob/Queue Storage instrumentation with connection, auth, and throttle events</Description>
     <NoWarn>CA1062;CA1822;CA2000;CA2007;CA2227;SYSLIB1015</NoWarn>
   </PropertyGroup>
 
@@ -22,6 +23,10 @@
     <EmbeddedResource Include="Schemas\azure-storage.otel.yaml">
       <LogicalName>OtelEvents.Azure.Storage.azure-storage.otel.yaml</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Causality/OtelEvents.Causality.csproj
+++ b/src/OtelEvents.Causality/OtelEvents.Causality.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Causal event linking processor for OpenTelemetry .NET — auto-generates eventId/parentEventId with UUID v7</Description>
     <NoWarn>CA1062;CA1822;CA2000</NoWarn>
   </PropertyGroup>
 
@@ -10,6 +11,10 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Cli/OtelEvents.Cli.csproj
+++ b/src/OtelEvents.Cli/OtelEvents.Cli.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>otel-events</ToolCommandName>
     <PackageId>OtelEvents.Cli</PackageId>
-    <Description>CLI tool for OtelEvents Schema — validate, generate, and document event schemas.</Description>
+    <Description>CLI tool for otel-events schema validation, code generation, version comparison, and documentation</Description>
     <NoWarn>CA1303</NoWarn>
   </PropertyGroup>
 
@@ -15,6 +15,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OtelEvents.Schema\OtelEvents.Schema.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Exporter.Json/OtelEvents.Exporter.Json.csproj
+++ b/src/OtelEvents.Exporter.Json/OtelEvents.Exporter.Json.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>AI-optimized JSONL exporter for OpenTelemetry .NET with sensitivity-based PII redaction</Description>
     <NoWarn>CA1002;CA1062;CA1305;CA1307;CA1720;CA1822;CA2000;CA2227</NoWarn>
   </PropertyGroup>
 
@@ -16,6 +17,10 @@
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Grpc/OtelEvents.Grpc.csproj
+++ b/src/OtelEvents.Grpc/OtelEvents.Grpc.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Zero-code gRPC call instrumentation with connection, auth, and throttle events</Description>
     <NoWarn>CA1062;CA1822;CA2000;CA2007;CA2227;SYSLIB1015</NoWarn>
   </PropertyGroup>
 
@@ -22,6 +23,10 @@
     <EmbeddedResource Include="Schemas\grpc.otel.yaml">
       <LogicalName>OtelEvents.Grpc.grpc.otel.yaml</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.HealthChecks/OtelEvents.HealthChecks.csproj
+++ b/src/OtelEvents.HealthChecks/OtelEvents.HealthChecks.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Structured health check events for ASP.NET Core with state change detection</Description>
     <NoWarn>CA1062;CA1822;CA2000;CA1873</NoWarn>
   </PropertyGroup>
 
@@ -11,6 +12,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Schema/OtelEvents.Schema.csproj
+++ b/src/OtelEvents.Schema/OtelEvents.Schema.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Schema-driven event code generator for OpenTelemetry .NET — parses .otel.yaml schemas and generates type-safe C# logging + metrics code</Description>
     <NoWarn>CA1002;CA1032;CA1064;CA1305;CA1307;CA1720;CA1822;CA1062;CA1859;CA1819</NoWarn>
   </PropertyGroup>
 
@@ -20,6 +21,10 @@
   <!-- Include MSBuild targets for NuGet schema packaging (auto-imported by consumers) -->
   <ItemGroup>
     <None Include="Build\OtelEvents.Schema.targets" Pack="true" PackagePath="buildTransitive\OtelEvents.Schema.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
+++ b/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>In-process event bus for OpenTelemetry .NET — subscribe to events with lambda or DI handlers</Description>
     <NoWarn>CA1031;CA1062;CA1711;CA1822;CA2000;CA2007;CA1848</NoWarn>
   </PropertyGroup>
 
@@ -12,6 +13,10 @@
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/OtelEvents.Testing/OtelEvents.Testing.csproj
+++ b/src/OtelEvents.Testing/OtelEvents.Testing.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Description>Test utilities for otel-events — InMemoryLogExporter, OtelEventsTestHost, LogAssertions</Description>
     <NoWarn>CA1062</NoWarn>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
@@ -10,6 +11,10 @@
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/tools/OtelEvents.Cli/OtelEvents.Cli.csproj
+++ b/tools/OtelEvents.Cli/OtelEvents.Cli.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>otel-events</ToolCommandName>
     <PackageId>OtelEvents.Cli</PackageId>
-    <Description>CLI tool for validating, generating, and comparing otel-events schema files</Description>
+    <Description>CLI tool for otel-events schema validation, code generation, version comparison, and documentation</Description>
     <NoWarn>CA1002;CA1307;CA1310;CA1515;CA1822;CA1859</NoWarn>
   </PropertyGroup>
 
@@ -19,6 +19,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OtelEvents.Schema\OtelEvents.Schema.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
All 12 packages now include README, description, license, tags, project URL. CHANGELOG updated for v0.2.0.