### PR TITLE
feat: Multi-target net8.0 + net10.0 — broadens adoption to .NET 8 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,18 @@ permissions:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet-version: ['10.0.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup .NET ${{ matrix.dotnet-version }}
+      # .NET 10 SDK builds both net8.0 and net10.0 targets.
+      # .NET 8 runtime is installed for targeting-pack support.
+      - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            8.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore
@@ -45,6 +46,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-reports-${{ matrix.dotnet-version }}
+          name: coverage-reports
           path: ./coverage/**/coverage.cobertura.xml
           retention-days: 30

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/README.md
+++ b/README.md
@@ -136,7 +136,16 @@ logger.EmitOrderPlaced(orderId, customerId, amount);
 
 ## Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download) or later
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) (builds both net8.0 and net10.0 targets)
+
+### Supported Target Frameworks
+
+| Package | Targets |
+|---------|---------|
+| Library packages (`OtelEvents.*`) | `net8.0`, `net10.0` |
+| `OtelEvents.Analyzers` | `netstandard2.0` (Roslyn requirement) |
+| `OtelEvents.Cli` | `net10.0` |
+| Test projects | `net10.0` |
 
 ## Project Structure
 

--- a/src/OtelEvents.Analyzers/OtelEvents.Analyzers.csproj
+++ b/src/OtelEvents.Analyzers/OtelEvents.Analyzers.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <!-- Roslyn analyzers must target netstandard2.0 -->
+    <TargetFrameworks />
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>

--- a/src/OtelEvents.Azure.Storage/Events/StorageInfrastructureEvents.cs
+++ b/src/OtelEvents.Azure.Storage/Events/StorageInfrastructureEvents.cs
@@ -255,7 +255,9 @@ internal static partial class StorageInfrastructureEvents
 
         var bytes = System.Text.Encoding.UTF8.GetBytes(identity);
         var hash = System.Security.Cryptography.SHA256.HashData(bytes);
-        return Convert.ToHexStringLower(hash)[..16]; // First 16 hex chars for brevity
+#pragma warning disable CA1308 // Lowercase hex is intentional for identity hashing
+        return Convert.ToHexString(hash).ToLowerInvariant()[..16]; // First 16 hex chars for brevity
+#pragma warning restore CA1308
     }
 
     /// <summary>

--- a/src/OtelEvents.Cli/OtelEvents.Cli.csproj
+++ b/src/OtelEvents.Cli/OtelEvents.Cli.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>otel-events</ToolCommandName>

--- a/src/OtelEvents.Grpc/Events/GrpcInfrastructureEvents.cs
+++ b/src/OtelEvents.Grpc/Events/GrpcInfrastructureEvents.cs
@@ -311,6 +311,8 @@ internal static partial class GrpcInfrastructureEvents
     internal static string HashIdentity(string value)
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
-        return Convert.ToHexStringLower(bytes)[..16];
+#pragma warning disable CA1308 // Lowercase hex is intentional for identity hashing
+        return Convert.ToHexString(bytes).ToLowerInvariant()[..16];
+#pragma warning restore CA1308
     }
 }

--- a/src/OtelEvents.Schema/Signing/SchemaSigner.cs
+++ b/src/OtelEvents.Schema/Signing/SchemaSigner.cs
@@ -28,7 +28,9 @@ public sealed class SchemaSigner
         }
 
         var hash = HMACSHA256.HashData(key, schemaContent);
-        return Convert.ToHexStringLower(hash);
+#pragma warning disable CA1308 // Lowercase hex is intentional for hash signatures
+        return Convert.ToHexString(hash).ToLowerInvariant();
+#pragma warning restore CA1308
     }
 
     /// <summary>

--- a/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
+++ b/src/OtelEvents.Subscriptions/OtelEventsSubscriptionExtensions.cs
@@ -71,6 +71,7 @@ public static class OtelEventsSubscriptionExtensions
         configureSubscriptions?.Invoke(builder);
 
         // Create the bounded channel with configured capacity and backpressure policy.
+#if NET9_0_OR_GREATER
         // The itemDropped callback fires whenever the channel drops an item in Drop* modes,
         // ensuring the channel_full counter is accurate regardless of FullMode.
         var channel = Channel.CreateBounded<DispatchItem>(
@@ -82,6 +83,18 @@ public static class OtelEventsSubscriptionExtensions
                 AllowSynchronousContinuations = false,
             },
             itemDropped: _ => SubscriptionMetrics.ChannelFull.Add(1));
+#else
+        // On .NET 8, the itemDropped callback is not available.
+        // Channel drops are silent — the channel_full counter will not fire.
+        var channel = Channel.CreateBounded<DispatchItem>(
+            new BoundedChannelOptions(options.ChannelCapacity)
+            {
+                FullMode = options.FullMode,
+                SingleReader = true,
+                SingleWriter = false,
+                AllowSynchronousContinuations = false,
+            });
+#endif
 
         // Register the channel as a singleton for processor and dispatcher to share
         services.AddSingleton(channel);

--- a/tests/OtelEvents.Analyzers.Tests/OtelEvents.Analyzers.Tests.csproj
+++ b/tests/OtelEvents.Analyzers.Tests/OtelEvents.Analyzers.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1707;NU1701</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.AspNetCore.Tests/OtelEvents.AspNetCore.Tests.csproj
+++ b/tests/OtelEvents.AspNetCore.Tests/OtelEvents.AspNetCore.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1063;CA1307;CA1707;CA1816;CA1848;CA2000;CA2007;CA2213;CA2234</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Azure.CosmosDb.Tests/OtelEvents.Azure.CosmosDb.Tests.csproj
+++ b/tests/OtelEvents.Azure.CosmosDb.Tests/OtelEvents.Azure.CosmosDb.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1031;CA1307;CA1310;CA1707;CA1848;CA1861;CA2000;CA2201</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Azure.Storage.Tests/OtelEvents.Azure.Storage.Tests.csproj
+++ b/tests/OtelEvents.Azure.Storage.Tests/OtelEvents.Azure.Storage.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1063;CA1307;CA1707;CA1816;CA1848;CA2000;CA2007;CA2213;CA2234</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Causality.Tests/OtelEvents.Causality.Tests.csproj
+++ b/tests/OtelEvents.Causality.Tests/OtelEvents.Causality.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1063;CA1307;CA1707;CA1816;CA1848;CA2000;CA2213;CA1873</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Cli.Tests/OtelEvents.Cli.Tests.csproj
+++ b/tests/OtelEvents.Cli.Tests/OtelEvents.Cli.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1307;CA1310;CA1707</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Exporter.Json.Tests/OtelEvents.Exporter.Json.Tests.csproj
+++ b/tests/OtelEvents.Exporter.Json.Tests/OtelEvents.Exporter.Json.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1031;CA1307;CA1310;CA1707;CA1848;CA1861;CA2000;CA2201</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Grpc.Tests/OtelEvents.Grpc.Tests.csproj
+++ b/tests/OtelEvents.Grpc.Tests/OtelEvents.Grpc.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1063;CA1307;CA1707;CA1816;CA1848;CA2000;CA2007;CA2213;CA2234</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.HealthChecks.Tests/OtelEvents.HealthChecks.Tests.csproj
+++ b/tests/OtelEvents.HealthChecks.Tests/OtelEvents.HealthChecks.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1031;CA1307;CA1310;CA1707;CA1848;CA1861;CA2000;CA2201</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Schema.Tests/OtelEvents.Schema.Tests.csproj
+++ b/tests/OtelEvents.Schema.Tests/OtelEvents.Schema.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1307;CA1310;CA1707</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Schema.Tests/SchemaSigningTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaSigningTests.cs
@@ -128,7 +128,9 @@ public sealed class SchemaSigningTests : IDisposable
     {
         // Cross-check against .NET's own HMAC-SHA256 to ensure correctness
         var content = Encoding.UTF8.GetBytes(SampleSchema);
-        var expected = Convert.ToHexStringLower(HMACSHA256.HashData(TestKey, content));
+#pragma warning disable CA1308 // Lowercase hex matches SchemaSigner output format
+        var expected = Convert.ToHexString(HMACSHA256.HashData(TestKey, content)).ToLowerInvariant();
+#pragma warning restore CA1308
 
         var actual = SchemaSigner.ComputeSignature(content, TestKey);
 

--- a/tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj
+++ b/tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1031;CA1307;CA1310;CA1515;CA1707;CA1711;CA1848;CA1849;CA1861;CA2000;CA2007;CA2201</NoWarn>
   </PropertyGroup>

--- a/tests/OtelEvents.Testing.Tests/OtelEvents.Testing.Tests.csproj
+++ b/tests/OtelEvents.Testing.Tests/OtelEvents.Testing.Tests.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>CA1307;CA1707;CA1848;CA2000;CA2007;CA1873</NoWarn>
   </PropertyGroup>

--- a/tools/OtelEvents.Cli/OtelEvents.Cli.csproj
+++ b/tools/OtelEvents.Cli/OtelEvents.Cli.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>otel-events</ToolCommandName>


### PR DESCRIPTION
All library packages now support net8.0 (LTS) + net10.0. Fixes:
- Convert.ToHexStringLower() → ToHexString().ToLowerInvariant() (net8 compat)
- Channel itemDropped callback guarded with #if NET9_0_OR_GREATER
- CI installs both SDKs for targeting packs
- Tests remain net10.0 only