### PR TITLE
refactor: Simplify Schema to String-Only Fields (#42)

### DIFF
--- a/docs/user-guide/04-getting-started.md
+++ b/docs/user-guide/04-getting-started.md
@@ -60,17 +60,11 @@ schema:
   meterName: "MyOrderService.Events.Orders"
   description: "Events for the order-processing service"
 
+# All fields are strings — no type annotation needed.
+# Use the shorthand list syntax for clean, concise schemas.
 fields:
-  orderId:
-    type: string
-    description: "Unique order identifier"
-    index: true
-
-  customerId:
-    type: string
-    description: "Customer who placed the order"
-    index: true
-
+  - orderId: { description: "Unique order identifier", index: true }
+  - customerId: { description: "Customer who placed the order", index: true }
 
 enums:
   OrderStatus:
@@ -89,15 +83,9 @@ events:
     description: "An order was placed by a customer"
     message: "Order {orderId} placed by {customerId} for {amount}"
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      customerId:
-        ref: customerId
-        required: true
-      amount:
-        type: double
-        required: true
+      - orderId: { required: true }
+      - customerId: { required: true }
+      - amount: { required: true }
     metrics:
       order.placed.count:
         type: counter
@@ -117,17 +105,9 @@ events:
     description: "An order's status changed"
     message: "Order {orderId} changed from {previousStatus} to {newStatus}"
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      previousStatus:
-        type: enum
-        values: [Pending, Confirmed, Shipped, Delivered, Cancelled]
-        required: true
-      newStatus:
-        type: enum
-        values: [Pending, Confirmed, Shipped, Delivered, Cancelled]
-        required: true
+      - orderId: { required: true }
+      - previousStatus: { required: true }
+      - newStatus: { required: true }
     tags:
       - commerce
       - orders
@@ -139,12 +119,8 @@ events:
     message: "Order {orderId} failed: {reason}"
     exception: true
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      reason:
-        type: string
-        required: true
+      - orderId: { required: true }
+      - reason: { required: true }
     metrics:
       order.failure.count:
         type: counter

--- a/docs/user-guide/05-schema-reference.md
+++ b/docs/user-guide/05-schema-reference.md
@@ -24,17 +24,6 @@ schema:
   description: "Events for MyService"  # Optional: human-readable description
   meterName: "MyCompany.MyService"     # Optional: OTEL Meter name (defaults to namespace)
 
-# ─── Reusable Field Definitions (optional) ───────────────────────────
-fields:
-  fieldName:
-    type: string                       # Required: field type (see type table)
-    description: "Field description"   # Optional: documentation
-    sensitivity: public                # Optional: public|internal|pii|credential
-    index: true                        # Optional: marks field as queryable
-    maxLength: 256                     # Optional: max string length (truncated)
-    unit: "ms"                         # Optional: unit of measurement
-    examples: ["value1", "value2"]     # Optional: example values
-
 # ─── Enum Type Definitions (optional) ────────────────────────────────
 enums:
   EnumName:
@@ -53,14 +42,10 @@ events:
     message: "Template with {field}"   # Required: message template
     exception: false                   # Optional: adds Exception parameter (default: false)
     fields:                            # Required: at least one field
-      fieldName:
-        type: string                   # Direct type definition
-        required: true                 # Required: true or false
-        sensitivity: pii               # Optional: override field-level sensitivity
-        maxLength: 512                 # Optional: override field-level maxLength
-      otherField:
-        ref: fieldName                 # Reference to a reusable field definition
-        required: false
+      - fieldName                      # Shorthand: just a name (string, optional)
+      - otherField: { required: true } # With annotation
+      - piiField: { sensitivity: pii } # With sensitivity
+      - bounded: { maxLength: 512 }    # With max length
     metrics:                           # Optional: associated metrics
       metric.name:
         type: counter                  # counter, histogram, or gauge
@@ -88,39 +73,40 @@ events:
 
 ---
 
-## Field Types
+## Fields
 
-| YAML Type | C# Type | JSON Type | Notes |
-|-----------|---------|-----------|-------|
-| `string` | `string` | `string` | Max length governed by `maxLength` or `MaxAttributeValueLength` (default: 4096) |
-| `int` | `int` | `number` | 32-bit signed integer |
-| `long` | `long` | `number` | 64-bit signed integer |
-| `double` | `double` | `number` | IEEE 754 double-precision |
-| `bool` | `bool` | `boolean` | |
-| `datetime` | `DateTimeOffset` | `string` | ISO 8601 UTC format |
-| `duration` | `TimeSpan` | `string` | ISO 8601 duration format |
-| `guid` | `Guid` | `string` | Standard GUID format |
-| `enum` | Generated C# enum | `string` | Serialized as string name, not integer |
-| `string[]` | `string[]` | `array` | Array of strings |
-| `int[]` | `int[]` | `array` | Array of integers |
-| `map` | `Dictionary<string, string>` | `object` | String key-value pairs |
+**All fields are strings.** The schema no longer supports typed fields (`int`, `bool`, `datetime`, etc.). Every field is emitted as a `string` attribute in the generated code. This simplifies the schema, aligns with OpenTelemetry's attribute model (which favors string attributes for log events), and eliminates type-mapping complexity.
 
----
+### Shorthand List Syntax (Recommended)
 
-## Field Attributes
+Fields are defined as a YAML list. Each entry can be a plain name or a name with annotations:
+
+```yaml
+fields:
+  - orderId                           # just a name (string, optional)
+  - customerId: { sensitivity: pii }  # with annotation
+  - amount: { required: true }        # with required
+  - notes: { maxLength: 1024 }        # with max length
+  - region: { index: true }           # with index
+```
+
+Multiple annotations can be combined:
+
+```yaml
+fields:
+  - email: { required: true, sensitivity: pii, maxLength: 256 }
+```
+
+### Field Attributes
 
 | Attribute | Required | Type | Default | Description |
 |-----------|----------|------|---------|-------------|
-| `type` | ✅* | string | — | Field type (see table above). *Not required if `ref` is used |
-| `ref` | ❌ | string | — | Reference to a reusable field definition. Mutually exclusive with `type` |
+| `name` | ✅ | string | — | Field name (the YAML key or list entry name) |
 | `description` | ❌ | string | — | Documentation for generated XML doc comments |
-| `required` | ✅ | bool | — | Whether the field is required. Required fields are non-nullable in generated code |
+| `required` | ❌ | bool | `false` | Whether the field is required. Required fields are non-nullable in generated code |
 | `sensitivity` | ❌ | string | `public` | Data sensitivity: `public`, `internal`, `pii`, `credential` |
-| `index` | ❌ | bool | `false` | Marks the field as queryable/indexed (documentation hint) |
 | `maxLength` | ❌ | int | — | Maximum string length. Values exceeding this are truncated with `"…[truncated]"` |
-| `unit` | ❌ | string | — | Unit of measurement (documentation + metric instrument unit) |
-| `examples` | ❌ | string[] | — | Example values (documentation hint) |
-| `values` | ❌ | string[] | — | Enum values when `type: enum`. Required when type is `enum` |
+| `index` | ❌ | bool | `false` | Marks the field as queryable/indexed (documentation hint) |
 
 ---
 
@@ -168,18 +154,10 @@ events:
     severity: INFO
     message: "HTTP {method} {path} completed with {statusCode} in {durationMs}ms"
     fields:
-      method:
-        type: string
-        required: true
-      path:
-        type: string
-        required: true
-      statusCode:
-        type: int
-        required: true
-      durationMs:
-        type: double
-        required: true
+      - method: { required: true }
+      - path: { required: true }
+      - statusCode: { required: true }
+      - durationMs: { required: true }
     metrics:
       http.request.duration:
         type: histogram
@@ -198,7 +176,7 @@ events:
 
 ## Enums
 
-Define enum types that can be referenced by events:
+Define enum types at the top level. Enum values are generated as **plain strings** — the `enums:` block serves as documentation and validation, but all enum fields are transmitted as string attributes:
 
 ```yaml
 enums:
@@ -221,10 +199,7 @@ enums:
 
 ### Generated Code
 
-For each enum, the code generator produces:
-
-1. A C# `enum` type
-2. A `ToStringFast()` extension method (zero-allocation, switch-based)
+For each enum, the code generator produces a C# `enum` type and a `ToStringFast()` extension method (zero-allocation, switch-based). At runtime, enum fields are serialized as their string name:
 
 ```csharp
 // Generated enum
@@ -243,26 +218,6 @@ public static class HealthStatusExtensions
 }
 ```
 
-### Inline Enums
-
-Enums can also be defined inline within an event field:
-
-```yaml
-events:
-  db.query.executed:
-    id: 2001
-    severity: DEBUG
-    message: "Query on {table} ({operation}) completed"
-    fields:
-      table:
-        type: string
-        required: true
-      operation:
-        type: enum
-        values: [SELECT, INSERT, UPDATE, DELETE, MERGE]
-        required: true
-```
-
 ---
 
 ## Sensitivity Classification
@@ -276,21 +231,10 @@ events:
 
 ```yaml
 fields:
-  httpMethod:
-    type: string
-    sensitivity: public        # Safe everywhere
-
-  hostName:
-    type: string
-    sensitivity: internal      # Redacted in Production
-
-  userId:
-    type: string
-    sensitivity: pii           # Redacted in Staging + Production
-
-  apiKey:
-    type: string
-    sensitivity: credential    # Always redacted
+  - httpMethod                         # Safe everywhere (default: public)
+  - hostName: { sensitivity: internal }  # Redacted in Production
+  - userId: { sensitivity: pii }         # Redacted in Staging + Production
+  - apiKey: { sensitivity: credential }  # Always redacted
 ```
 
 See [Chapter 10 — Security & Privacy](10-security-privacy.md) for the complete redaction matrix.
@@ -303,14 +247,8 @@ Use `maxLength` to prevent unbounded attribute values:
 
 ```yaml
 fields:
-  userAgent:
-    type: string
-    sensitivity: pii
-    maxLength: 512            # Truncated at 512 characters
-
-  httpPath:
-    type: string
-    maxLength: 256            # Truncated at 256 characters
+  - userAgent: { sensitivity: pii, maxLength: 512 }   # Truncated at 512 characters
+  - httpPath: { maxLength: 256 }                       # Truncated at 256 characters
 ```
 
 Values exceeding `maxLength` are truncated with `"…[truncated]"`. The global default maximum is `MaxAttributeValueLength` (4096 characters).
@@ -352,12 +290,8 @@ events:
     message: "Order {orderId} failed: {reason}"
     exception: true            # Adds Exception parameter
     fields:
-      orderId:
-        type: string
-        required: true
-      reason:
-        type: string
-        required: true
+      - orderId: { required: true }
+      - reason: { required: true }
 ```
 
 Generated usage:
@@ -388,10 +322,7 @@ The schema parser validates at build time. Violations produce clear build errors
 | `OTEL_SCHEMA_001` | Duplicate event name within merged schemas |
 | `OTEL_SCHEMA_002` | Invalid severity (must be TRACE, DEBUG, INFO, WARN, ERROR, FATAL) |
 | `OTEL_SCHEMA_003` | Message template `{placeholder}` does not match any field name |
-| `OTEL_SCHEMA_004` | Unresolved `ref` (field or enum reference not found) |
-| `OTEL_SCHEMA_005` | Invalid field type |
 | `OTEL_SCHEMA_006` | Invalid event name format (must be lowercase, dot-namespaced) |
-| `OTEL_SCHEMA_007` | Required field missing type (directly or via ref) |
 | `OTEL_SCHEMA_008` | Invalid metric type (must be counter, histogram, or gauge) |
 | `OTEL_SCHEMA_009` | Empty enum definition (must have at least one value) |
 | `OTEL_SCHEMA_010` | Invalid semver version |
@@ -430,6 +361,46 @@ For each schema, the code generator produces:
 | `{EnumName}.g.cs` | One file per enum type defined in the schema |
 | `{SchemaName}Metrics.g.cs` | Static `Meter` / `Counter` / `Histogram` instances |
 | `{SchemaName}MetricsServiceCollectionExtensions.g.cs` | DI registration extension (only for `meter_lifecycle: di`) |
+
+---
+
+## Backward Compatibility
+
+The following properties are **accepted but ignored** by the schema parser for backward compatibility with older schema files:
+
+| Property | Status | Notes |
+|----------|--------|-------|
+| `type` | Accepted, ignored | All fields are strings. Specifying `type: string` (or any other type) is harmless but has no effect |
+| `ref` | Removed | Field referencing is no longer supported. Inline all field definitions directly |
+| `values` | Removed | Inline enum values on fields are no longer supported. Use top-level `enums:` instead |
+| `examples` | Removed | Example values are no longer part of the schema |
+| `unit` | Removed | Unit of measurement on fields is removed. Units on **metrics** are still supported |
+
+### Migrating from Map Syntax
+
+The old map-style field syntax still works and is parsed correctly:
+
+```yaml
+# Old syntax — still accepted
+fields:
+  orderId:
+    type: string        # accepted but ignored
+    required: true
+  customerId:
+    type: string        # accepted but ignored
+    sensitivity: pii
+```
+
+However, the **recommended** syntax is the shorthand list format:
+
+```yaml
+# New syntax — recommended
+fields:
+  - orderId: { required: true }
+  - customerId: { sensitivity: pii }
+```
+
+Both forms produce identical generated code.
 
 ---
 

--- a/samples/OtelEvents.Sample.WebApi/Events/OrderEvents.g.cs
+++ b/samples/OtelEvents.Sample.WebApi/Events/OrderEvents.g.cs
@@ -12,12 +12,13 @@ namespace OtelEvents.Sample.WebApi.Events;
 /// <summary>
 /// Pre-compiled [LoggerMessage] methods and metrics for order lifecycle events.
 /// Demonstrates typed transactions: start/success/failure/event patterns.
+/// All fields are strings (simplified schema — Issue #42).
 /// </summary>
 internal static partial class OrderEvents
 {
     // ─── Meter & Instruments ────────────────────────────────────────────
 
-    private static readonly Meter s_meter = new("Sample.Events.Orders", "1.0.0");
+    private static readonly Meter s_meter = new("Sample.Events.Orders", "1.1.0");
 
     internal static readonly Counter<long> OrderPlacedCount =
         s_meter.CreateCounter<long>("sample.order.placed.count", "orders", "Total orders placed");
@@ -40,7 +41,7 @@ internal static partial class OrderEvents
         ILogger logger,
         string orderId,
         string customerId,
-        double amount);
+        string amount);
 
     /// <summary>
     /// Emits <c>order.placed</c> (type: start) — creates a transaction scope.
@@ -50,13 +51,15 @@ internal static partial class OrderEvents
         this ILogger logger,
         string orderId,
         string customerId,
-        double amount)
+        string amount)
     {
         LogOrderPlaced(logger, orderId, customerId, amount);
 
         OrderPlacedCount.Add(1,
             new KeyValuePair<string, object?>("customerId", customerId));
-        OrderPlacedAmount.Record(amount);
+
+        if (double.TryParse(amount, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var amountValue))
+            OrderPlacedAmount.Record(amountValue);
 
         return OtelEventsTransactionScope.Begin("order.placed");
     }

--- a/samples/OtelEvents.Sample.WebApi/schemas/orders.otel.yaml
+++ b/samples/OtelEvents.Sample.WebApi/schemas/orders.otel.yaml
@@ -2,6 +2,9 @@
 # Demonstrates typed transactions for an order lifecycle workflow.
 # The C# code in Events/ is pre-generated — you can modify this schema
 # and regenerate using the OtelEvents CLI tool.
+#
+# All fields are strings (simplified schema — Issue #42).
+# Old 'type:' syntax is accepted but ignored for backward compatibility.
 
 schema:
   name: "Sample.Orders"
@@ -11,37 +14,13 @@ schema:
   description: "Schema-defined order lifecycle events with typed transactions"
 
 fields:
-  orderId:
-    type: string
-    description: "Unique order identifier"
-    index: true
-
-  customerId:
-    type: string
-    description: "Customer who placed the order"
-    index: true
-
-  amount:
-    type: double
-    description: "Order total amount in USD"
-    unit: "USD"
-
-  status:
-    type: string
-    description: "Order completion status (Shipped, Delivered, etc.)"
-    index: true
-
-  reason:
-    type: string
-    description: "Failure reason or error description"
-
-  carrier:
-    type: string
-    description: "Shipping carrier name"
-
-  trackingNumber:
-    type: string
-    description: "Shipment tracking number"
+  - orderId: { description: "Unique order identifier", index: true }
+  - customerId: { description: "Customer who placed the order", index: true }
+  - amount: { description: "Order total amount in USD" }
+  - status: { description: "Order completion status (Shipped, Delivered, etc.)", index: true }
+  - reason: { description: "Failure reason or error description" }
+  - carrier: { description: "Shipping carrier name" }
+  - trackingNumber: { description: "Shipment tracking number" }
 
 events:
   # ── Transaction Start: creates a causal scope + starts timer ──────────────
@@ -52,15 +31,9 @@ events:
     description: "A new order was placed by a customer. Begins the order transaction."
     message: "Order {orderId} placed by customer {customerId} for ${amount}"
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      customerId:
-        ref: customerId
-        required: true
-      amount:
-        ref: amount
-        required: true
+      - orderId: { required: true }
+      - customerId: { required: true }
+      - amount: { required: true }
     metrics:
       sample.order.placed.count:
         type: counter
@@ -86,14 +59,9 @@ events:
     description: "An order was completed and shipped successfully."
     message: "Order {orderId} shipped via {carrier}"
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      carrier:
-        ref: carrier
-        required: true
-      trackingNumber:
-        ref: trackingNumber
+      - orderId: { required: true }
+      - carrier: { required: true }
+      - trackingNumber
     tags:
       - orders
       - business
@@ -108,12 +76,8 @@ events:
     message: "Order {orderId} failed: {reason}"
     exception: true
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      reason:
-        ref: reason
-        required: true
+      - orderId: { required: true }
+      - reason: { required: true }
     metrics:
       sample.order.failed.count:
         type: counter
@@ -131,12 +95,7 @@ events:
     description: "A note was added to an order. No transaction effect."
     message: "Note added to order {orderId}: {note}"
     fields:
-      orderId:
-        ref: orderId
-        required: true
-      note:
-        type: string
-        description: "The note text"
-        required: true
+      - orderId: { required: true }
+      - note: { required: true, description: "The note text" }
     tags:
       - orders

--- a/src/OtelEvents.Schema/CodeGen/CodeGenerator.cs
+++ b/src/OtelEvents.Schema/CodeGen/CodeGenerator.cs
@@ -619,18 +619,17 @@ public sealed class CodeGenerator
             }
             else if (metric.Type == MetricType.Histogram)
             {
-                // Try to match a field by the last segment of the metric name
+                // Try to match a field by the last segment of the metric name.
+                // Since all fields are strings, use double.TryParse() to convert.
                 var lastSegment = NamingHelper.GetLastSegment(metric.Name);
                 var matchingField = evt.Fields.FirstOrDefault(f =>
-                    f.Name.Equals(lastSegment, StringComparison.OrdinalIgnoreCase) &&
-                    f.Type is not null &&
-                    TypeMapper.IsNumericType(f.Type.Value));
+                    f.Name.Equals(lastSegment, StringComparison.OrdinalIgnoreCase));
 
                 if (matchingField is not null)
                 {
                     var paramName = NamingHelper.ToCamelCase(matchingField.Name);
-                    var castPrefix = matchingField.Type != FieldType.Double ? "(double)" : "";
-                    sb.AppendLine($"        {accessor}.Record({castPrefix}{paramName}{tagsSuffix});");
+                    sb.AppendLine($"        if (double.TryParse({paramName}, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var {paramName}Value))");
+                    sb.AppendLine($"            {accessor}.Record({paramName}Value{tagsSuffix});");
                 }
                 else
                 {
@@ -646,31 +645,9 @@ public sealed class CodeGenerator
 
     private static List<EnumDefinition> CollectAllEnums(SchemaDocument doc)
     {
-        var enums = new List<EnumDefinition>(doc.Enums);
-        var existingNames = new HashSet<string>(
-            enums.Select(e => NamingHelper.ToPascalCase(e.Name)),
-            StringComparer.Ordinal);
-
-        foreach (var evt in doc.Events)
-        {
-            foreach (var field in evt.Fields)
-            {
-                if (field.Type == FieldType.Enum && field.Values is { Count: > 0 })
-                {
-                    var enumName = NamingHelper.ToPascalCase(field.Name);
-                    if (existingNames.Add(enumName))
-                    {
-                        enums.Add(new EnumDefinition
-                        {
-                            Name = field.Name,
-                            Values = field.Values
-                        });
-                    }
-                }
-            }
-        }
-
-        return enums;
+        // Only collect top-level enums; inline field enums are no longer supported
+        // since all fields are strings.
+        return new List<EnumDefinition>(doc.Enums);
     }
 
     private static void AppendFieldParameters(
@@ -681,16 +658,15 @@ public sealed class CodeGenerator
         foreach (var field in fields)
         {
             sb.Append(", ");
-            var csharpType = TypeMapper.GetFieldCSharpType(field);
             var paramName = NamingHelper.ToCamelCase(field.Name);
 
             if (field.Required)
             {
-                sb.Append($"{csharpType} {paramName}");
+                sb.Append($"string {paramName}");
             }
             else
             {
-                sb.Append($"{csharpType}? {paramName} = null");
+                sb.Append($"string? {paramName} = null");
             }
         }
 

--- a/src/OtelEvents.Schema/CodeGen/TypeMapper.cs
+++ b/src/OtelEvents.Schema/CodeGen/TypeMapper.cs
@@ -3,51 +3,16 @@ using OtelEvents.Schema.Models;
 namespace OtelEvents.Schema.CodeGen;
 
 /// <summary>
-/// Maps YAML schema types to C# types and YAML severity to LogLevel.
+/// Maps schema types to C# types and YAML severity to LogLevel.
+/// All fields are now strings — type mapping is simplified.
 /// </summary>
 public static class TypeMapper
 {
     /// <summary>
-    /// Maps a <see cref="FieldType"/> to its C# type name.
+    /// Returns the C# type for any field. Always returns "string" since
+    /// all schema fields are string-typed.
     /// </summary>
-    public static string ToCSharpType(FieldType fieldType) => fieldType switch
-    {
-        FieldType.String => "string",
-        FieldType.Int => "int",
-        FieldType.Long => "long",
-        FieldType.Double => "double",
-        FieldType.Bool => "bool",
-        FieldType.DateTime => "DateTimeOffset",
-        FieldType.Duration => "TimeSpan",
-        FieldType.Guid => "Guid",
-        FieldType.StringArray => "string[]",
-        FieldType.IntArray => "int[]",
-        FieldType.Map => "Dictionary<string, string>",
-        FieldType.Enum => "string", // Resolved separately via GetFieldCSharpType
-        _ => "object"
-    };
-
-    /// <summary>
-    /// Gets the C# type for a field, handling enum references and inline enums.
-    /// </summary>
-    public static string GetFieldCSharpType(FieldDefinition field)
-    {
-        if (field.Type == FieldType.Enum)
-        {
-            if (field.Ref is not null)
-                return NamingHelper.ToPascalCase(field.Ref);
-
-            if (field.Values is { Count: > 0 })
-                return NamingHelper.ToPascalCase(field.Name);
-
-            return "string";
-        }
-
-        if (field.Type is not null)
-            return ToCSharpType(field.Type.Value);
-
-        return "object";
-    }
+    public static string GetFieldCSharpType(FieldDefinition field) => "string";
 
     /// <summary>
     /// Maps a <see cref="Severity"/> to its C# LogLevel string.
@@ -84,16 +49,5 @@ public static class TypeMapper
         MetricType.Histogram => "CreateHistogram",
         MetricType.Gauge => "CreateCounter", // Simplified: gauge as counter for now
         _ => "CreateCounter"
-    };
-
-    /// <summary>
-    /// Checks whether a field type is numeric (can be recorded in a Histogram).
-    /// </summary>
-    public static bool IsNumericType(FieldType fieldType) => fieldType switch
-    {
-        FieldType.Int => true,
-        FieldType.Long => true,
-        FieldType.Double => true,
-        _ => false
     };
 }

--- a/src/OtelEvents.Schema/Comparison/SchemaComparer.cs
+++ b/src/OtelEvents.Schema/Comparison/SchemaComparer.cs
@@ -110,21 +110,6 @@ public sealed class SchemaComparer
             }
         }
 
-        // Fields in both — check type changes
-        foreach (var oldField in oldFields)
-        {
-            if (newByName.TryGetValue(oldField.Name, out var newField))
-            {
-                if (oldField.Type != newField.Type)
-                {
-                    changes.Add(new SchemaChange
-                    {
-                        Kind = SchemaChangeKind.FieldTypeChanged,
-                        Name = $"{eventName}.{oldField.Name}",
-                        Description = $"Field '{oldField.Name}' in event '{eventName}' changed type from '{oldField.Type}' to '{newField.Type}'."
-                    });
-                }
-            }
-        }
+        // Fields in both — type changes no longer apply since all fields are strings
     }
 }

--- a/src/OtelEvents.Schema/Documentation/SchemaDocumentationGenerator.cs
+++ b/src/OtelEvents.Schema/Documentation/SchemaDocumentationGenerator.cs
@@ -182,37 +182,10 @@ public sealed class SchemaDocumentationGenerator
         sb.AppendLine();
     }
 
-    private static readonly Dictionary<FieldType, string> FieldTypeDisplayNames = new()
-    {
-        [FieldType.String] = "string",
-        [FieldType.Int] = "int",
-        [FieldType.Long] = "long",
-        [FieldType.Double] = "double",
-        [FieldType.Bool] = "bool",
-        [FieldType.DateTime] = "datetime",
-        [FieldType.Duration] = "duration",
-        [FieldType.Guid] = "guid",
-        [FieldType.Enum] = "enum",
-        [FieldType.StringArray] = "string[]",
-        [FieldType.IntArray] = "int[]",
-        [FieldType.Map] = "map"
-    };
-
     private static string FormatFieldType(FieldDefinition field)
     {
-        if (field.Type == FieldType.Enum && field.Ref is not null)
-        {
-            return $"enum ({field.Ref})";
-        }
-
-        if (field.Type is null)
-        {
-            return "ref";
-        }
-
-        return FieldTypeDisplayNames.TryGetValue(field.Type.Value, out var displayName)
-            ? displayName
-            : field.Type.Value.ToString();
+        // All fields are strings in the simplified schema
+        return "string";
     }
 
     private static string FormatSensitivity(Sensitivity sensitivity)
@@ -228,19 +201,7 @@ public sealed class SchemaDocumentationGenerator
 
     private static string FormatFieldDescription(FieldDefinition field)
     {
-        var parts = new List<string>();
-
-        if (field.Description is not null)
-        {
-            parts.Add(field.Description);
-        }
-
-        if (field.Unit is not null)
-        {
-            parts.Add($"Unit: {field.Unit}");
-        }
-
-        return string.Join(" · ", parts);
+        return field.Description ?? "";
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/src/OtelEvents.Schema/Models/FieldDefinition.cs
+++ b/src/OtelEvents.Schema/Models/FieldDefinition.cs
@@ -2,15 +2,12 @@ namespace OtelEvents.Schema.Models;
 
 /// <summary>
 /// Defines a field within an event or as a reusable shared definition.
-/// Fields carry the structured data attached to each event occurrence.
+/// All fields are strings — type information has been removed in favor of a simplified schema.
 /// </summary>
 public sealed class FieldDefinition
 {
-    /// <summary>Name of the field (key in the YAML fields map).</summary>
+    /// <summary>Name of the field (key in the YAML fields map or list item).</summary>
     public required string Name { get; init; }
-
-    /// <summary>The data type of this field. Null when using a ref.</summary>
-    public FieldType? Type { get; init; }
 
     /// <summary>Human-readable description of the field.</summary>
     public string? Description { get; init; }
@@ -21,26 +18,11 @@ public sealed class FieldDefinition
     /// <summary>Data sensitivity classification (defaults to Public).</summary>
     public Sensitivity Sensitivity { get; init; } = Sensitivity.Public;
 
-    /// <summary>Maximum string length. Only valid for string-typed fields.</summary>
+    /// <summary>Maximum string length constraint.</summary>
     public int? MaxLength { get; init; }
 
     /// <summary>Whether this field should be indexed for querying.</summary>
     public bool Index { get; init; }
-
-    /// <summary>Reference to a reusable field or enum definition.</summary>
-    public string? Ref { get; init; }
-
-    /// <summary>Unit of measure (e.g., "ms", "bytes").</summary>
-    public string? Unit { get; init; }
-
-    /// <summary>Example values for documentation.</summary>
-    public List<string>? Examples { get; init; }
-
-    /// <summary>Inline enum values when type is enum.</summary>
-    public List<string>? Values { get; init; }
-
-    /// <summary>Raw type string from YAML (for validation of invalid types).</summary>
-    internal string? RawType { get; init; }
 
     /// <summary>Raw sensitivity string from YAML (for validation of invalid values).</summary>
     internal string? RawSensitivity { get; init; }

--- a/src/OtelEvents.Schema/Models/FieldType.cs
+++ b/src/OtelEvents.Schema/Models/FieldType.cs
@@ -2,55 +2,48 @@ namespace OtelEvents.Schema.Models;
 
 /// <summary>
 /// Supported field types in the YAML schema.
-/// Maps YAML type strings to strongly-typed enum values.
+/// Deprecated: All fields are now strings. This enum is retained for backward compatibility only.
 /// </summary>
+[Obsolete("All fields are now strings. FieldType is retained for backward-compatible YAML parsing only.")]
 public enum FieldType
 {
-    String,
-    Int,
-    Long,
-    Double,
-    Bool,
-    DateTime,
-    Duration,
-    Guid,
-    Enum,
-    StringArray,
-    IntArray,
-    Map
+    String
 }
 
 /// <summary>
 /// Extension methods for FieldType parsing and validation.
+/// Deprecated: All fields are now strings. Retained for backward-compatible YAML parsing.
 /// </summary>
+[Obsolete("All fields are now strings. FieldType parsing is retained for backward compatibility only.")]
 public static class FieldTypeExtensions
 {
     private static readonly Dictionary<string, FieldType> TypeMap = new(StringComparer.OrdinalIgnoreCase)
     {
         ["string"] = FieldType.String,
-        ["int"] = FieldType.Int,
-        ["long"] = FieldType.Long,
-        ["double"] = FieldType.Double,
-        ["bool"] = FieldType.Bool,
-        ["datetime"] = FieldType.DateTime,
-        ["duration"] = FieldType.Duration,
-        ["guid"] = FieldType.Guid,
-        ["enum"] = FieldType.Enum,
-        ["string[]"] = FieldType.StringArray,
-        ["int[]"] = FieldType.IntArray,
-        ["map"] = FieldType.Map
+        ["int"] = FieldType.String,
+        ["long"] = FieldType.String,
+        ["double"] = FieldType.String,
+        ["bool"] = FieldType.String,
+        ["datetime"] = FieldType.String,
+        ["duration"] = FieldType.String,
+        ["guid"] = FieldType.String,
+        ["enum"] = FieldType.String,
+        ["string[]"] = FieldType.String,
+        ["int[]"] = FieldType.String,
+        ["map"] = FieldType.String
     };
 
     /// <summary>
-    /// Tries to parse a YAML type string into a <see cref="FieldType"/>.
+    /// Checks whether a YAML type string is a recognized type name.
+    /// All recognized types map to String (retained for backward compatibility).
     /// </summary>
-    public static bool TryParseFieldType(string yamlType, out FieldType fieldType)
+    public static bool IsRecognizedTypeName(string yamlType)
     {
-        return TypeMap.TryGetValue(yamlType, out fieldType);
+        return TypeMap.ContainsKey(yamlType);
     }
 
     /// <summary>
-    /// Returns the set of valid YAML type names.
+    /// Returns the set of valid YAML type names (for backward-compatible parsing).
     /// </summary>
     public static IReadOnlyCollection<string> ValidTypeNames => TypeMap.Keys;
 }

--- a/src/OtelEvents.Schema/Parsing/SchemaParser.cs
+++ b/src/OtelEvents.Schema/Parsing/SchemaParser.cs
@@ -208,16 +208,17 @@ public sealed class SchemaParser
 
     private static List<FieldDefinition> ParseSharedFields(YamlMappingNode root)
     {
-        var fieldsNode = GetOptionalMapping(root, "fields");
-        if (fieldsNode is null) return [];
+        // Support both list syntax (new) and map syntax (old/backward compat)
+        var scalarKey = new YamlScalarNode("fields");
+        if (!root.Children.TryGetValue(scalarKey, out var fieldsValue))
+            return [];
 
-        var fields = new List<FieldDefinition>();
-        foreach (var entry in fieldsNode.Children)
+        return fieldsValue switch
         {
-            var name = ((YamlScalarNode)entry.Key).Value!;
-            fields.Add(ParseFieldDefinition(name, entry.Value));
-        }
-        return fields;
+            YamlSequenceNode sequence => ParseFieldsFromSequence(sequence),
+            YamlMappingNode mapping => ParseFieldsFromMapping(mapping),
+            _ => []
+        };
     }
 
     private static List<EnumDefinition> ParseEnums(YamlMappingNode root)
@@ -315,14 +316,65 @@ public sealed class SchemaParser
 
     private static List<FieldDefinition> ParseEventFields(YamlMappingNode eventNode, string eventName)
     {
-        var fieldsNode = GetOptionalMapping(eventNode, "fields");
-        if (fieldsNode is null) return [];
+        // Support both list syntax (new) and map syntax (old/backward compat)
+        var scalarKey = new YamlScalarNode("fields");
+        if (!eventNode.Children.TryGetValue(scalarKey, out var fieldsValue))
+            return [];
 
+        return fieldsValue switch
+        {
+            YamlSequenceNode sequence => ParseFieldsFromSequence(sequence),
+            YamlMappingNode mapping => ParseFieldsFromMapping(mapping),
+            _ => []
+        };
+    }
+
+    /// <summary>
+    /// Parses fields from a YAML mapping node (old map syntax — backward compatible).
+    /// The <c>type:</c> and <c>ref:</c> keys are accepted but silently ignored.
+    /// </summary>
+    private static List<FieldDefinition> ParseFieldsFromMapping(YamlMappingNode mapping)
+    {
         var fields = new List<FieldDefinition>();
-        foreach (var entry in fieldsNode.Children)
+        foreach (var entry in mapping.Children)
         {
             var name = ((YamlScalarNode)entry.Key).Value!;
             fields.Add(ParseFieldDefinition(name, entry.Value));
+        }
+        return fields;
+    }
+
+    /// <summary>
+    /// Parses fields from a YAML sequence node (new shorthand list syntax).
+    /// Supports:
+    ///   - orderId                           (just a name — scalar)
+    ///   - customerId: { sensitivity: pii }  (name with annotations — single-entry mapping)
+    /// </summary>
+    private static List<FieldDefinition> ParseFieldsFromSequence(YamlSequenceNode sequence)
+    {
+        var fields = new List<FieldDefinition>();
+        foreach (var item in sequence.Children)
+        {
+            switch (item)
+            {
+                case YamlScalarNode scalar when scalar.Value is not null:
+                    // Simple field name only: "- orderId"
+                    fields.Add(new FieldDefinition { Name = scalar.Value });
+                    break;
+
+                case YamlMappingNode mapping when mapping.Children.Count == 1:
+                {
+                    // Field with annotations: "- customerId: { sensitivity: pii }"
+                    var entry = mapping.Children.First();
+                    var name = ((YamlScalarNode)entry.Key).Value!;
+                    fields.Add(ParseFieldDefinition(name, entry.Value));
+                    break;
+                }
+
+                default:
+                    throw new SchemaParseException(ErrorCodes.InvalidEventNameFormat,
+                        "Field list items must be a string name or a single-key mapping with annotations.");
+            }
         }
         return fields;
     }
@@ -331,15 +383,8 @@ public sealed class SchemaParser
     {
         if (node is YamlMappingNode mapping)
         {
-            var typeStr = GetOptionalScalar(mapping, "type");
-            FieldType? fieldType = null;
-            if (typeStr is not null)
-            {
-                if (FieldTypeExtensions.TryParseFieldType(typeStr, out var parsed))
-                    fieldType = parsed;
-                else
-                    fieldType = null; // Will be caught by validation
-            }
+            // Accept 'type:' and 'ref:' keys for backward compat — silently ignored
+            // (All fields are now strings, refs are inlined)
 
             var sensitivityStr = GetOptionalScalar(mapping, "sensitivity");
             var sensitivity = Sensitivity.Public;
@@ -360,54 +405,33 @@ public sealed class SchemaParser
                 maxLength = -1;
             }
 
-            var refValue = GetOptionalScalar(mapping, "ref");
             var description = GetOptionalScalar(mapping, "description");
             var required = GetOptionalScalarBool(mapping, "required");
             var index = GetOptionalScalarBool(mapping, "index");
-            var unit = GetOptionalScalar(mapping, "unit");
 
-            var examples = GetOptionalSequence(mapping, "examples")?
-                .Children.OfType<YamlScalarNode>().Select(n => n.Value!).ToList();
-
-            var values = GetOptionalSequence(mapping, "values")?
-                .Children.OfType<YamlScalarNode>().Select(n => n.Value!).ToList();
-
-            // Preserve the raw type string for validation when type is invalid
             return new FieldDefinition
             {
                 Name = name,
-                Type = fieldType,
                 Description = description,
                 Required = required,
                 Sensitivity = sensitivity,
                 MaxLength = maxLength,
                 Index = index,
-                Ref = refValue,
-                Unit = unit,
-                Examples = examples,
-                Values = values,
-                RawType = typeStr,
                 RawSensitivity = sensitivityStr,
                 RawMaxLength = maxLengthStr
             };
         }
 
-        // Simple scalar value — treat as type shorthand
-        if (node is YamlScalarNode scalar)
+        // Simple scalar value — treat as a field name (backward compat: old type shorthand ignored)
+        if (node is YamlScalarNode)
         {
-            FieldType? fieldType = null;
-            if (scalar.Value is not null && FieldTypeExtensions.TryParseFieldType(scalar.Value, out var parsed))
-                fieldType = parsed;
-
             return new FieldDefinition
             {
-                Name = name,
-                Type = fieldType,
-                RawType = scalar.Value
+                Name = name
             };
         }
 
-        throw new SchemaParseException(ErrorCodes.InvalidType,
+        throw new SchemaParseException(ErrorCodes.InvalidEventNameFormat,
             $"Field '{name}' has an invalid structure.");
     }
 

--- a/src/OtelEvents.Schema/Validation/SchemaValidator.cs
+++ b/src/OtelEvents.Schema/Validation/SchemaValidator.cs
@@ -283,38 +283,9 @@ public sealed partial class SchemaValidator
             });
         }
 
-        // OTEL_SCHEMA_005: Type validity (if raw type was provided but didn't parse)
-        if (field.RawType is not null && field.Type is null && field.Ref is null)
-        {
-            errors.Add(new SchemaError
-            {
-                Code = ErrorCodes.InvalidType,
-                Message = $"Field '{field.Name}' in event '{eventName}' has invalid type '{field.RawType}'."
-            });
-        }
-
-        // OTEL_SCHEMA_004: Ref resolution
-        if (field.Ref is not null)
-        {
-            if (!sharedFields.ContainsKey(field.Ref) && !enums.ContainsKey(field.Ref))
-            {
-                errors.Add(new SchemaError
-                {
-                    Code = ErrorCodes.UnresolvedRef,
-                    Message = $"Field '{field.Name}' in event '{eventName}' references undefined field/enum '{field.Ref}'."
-                });
-            }
-        }
-
-        // OTEL_SCHEMA_007: Required field must have a type (directly or via ref)
-        if (field.Required && field.Type is null && field.Ref is null)
-        {
-            errors.Add(new SchemaError
-            {
-                Code = ErrorCodes.RequiredFieldMissingType,
-                Message = $"Required field '{field.Name}' in event '{eventName}' must have a type or ref."
-            });
-        }
+        // OTEL_SCHEMA_005: Removed — all fields are strings, no type validation needed.
+        // OTEL_SCHEMA_004: Removed — ref field referencing has been removed.
+        // OTEL_SCHEMA_007: Removed — required fields no longer need a type/ref (all are strings).
 
         // OTEL_SCHEMA_014: Sensitivity validity
         if (field.RawSensitivity is not null &&

--- a/tests/OtelEvents.Schema.Tests/CodeGeneratorTests.cs
+++ b/tests/OtelEvents.Schema.Tests/CodeGeneratorTests.cs
@@ -123,7 +123,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }]
         });
 
         var files = _generator.GenerateFromSchema(doc);
@@ -145,7 +145,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }]
         });
 
         var files = _generator.GenerateFromSchema(doc);
@@ -166,7 +166,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }]
         });
 
         var files = _generator.GenerateFromSchema(doc);
@@ -204,9 +204,9 @@ public class CodeGeneratorTests
             Message = "Order {orderId} placed by {userId} for {amount}",
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "userId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = true }
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "userId", Required = true },
+                new FieldDefinition { Name = "amount", Required = true }
             ]
         });
 
@@ -215,7 +215,7 @@ public class CodeGeneratorTests
 
         Assert.Contains("string orderId", content);
         Assert.Contains("string userId", content);
-        Assert.Contains("double amount", content);
+        Assert.Contains("string amount", content);
     }
 
     [Fact]
@@ -229,9 +229,9 @@ public class CodeGeneratorTests
             Message = "Order {orderId} placed",
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "userId", Type = FieldType.String, Required = false },
-                new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = false }
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "userId", Required = false },
+                new FieldDefinition { Name = "amount", Required = false }
             ]
         });
 
@@ -239,7 +239,7 @@ public class CodeGeneratorTests
         var content = files.First(f => f.FileName.Contains("Events")).Content;
 
         Assert.Contains("string? userId", content);
-        Assert.Contains("double? amount", content);
+        Assert.Contains("string? amount", content);
     }
 
     [Fact]
@@ -252,7 +252,7 @@ public class CodeGeneratorTests
             Severity = Severity.Error,
             Message = "Order {orderId} failed",
             Exception = true,
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }]
         });
 
         var files = _generator.GenerateFromSchema(doc);
@@ -339,17 +339,17 @@ public class CodeGeneratorTests
             Message = "Type test",
             Fields =
             [
-                new FieldDefinition { Name = "strField", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "intField", Type = FieldType.Int, Required = true },
-                new FieldDefinition { Name = "longField", Type = FieldType.Long, Required = true },
-                new FieldDefinition { Name = "doubleField", Type = FieldType.Double, Required = true },
-                new FieldDefinition { Name = "boolField", Type = FieldType.Bool, Required = true },
-                new FieldDefinition { Name = "dateField", Type = FieldType.DateTime, Required = true },
-                new FieldDefinition { Name = "durationField", Type = FieldType.Duration, Required = true },
-                new FieldDefinition { Name = "guidField", Type = FieldType.Guid, Required = true },
-                new FieldDefinition { Name = "strArrayField", Type = FieldType.StringArray, Required = true },
-                new FieldDefinition { Name = "intArrayField", Type = FieldType.IntArray, Required = true },
-                new FieldDefinition { Name = "mapField", Type = FieldType.Map, Required = true }
+                new FieldDefinition { Name = "strField", Required = true },
+                new FieldDefinition { Name = "intField", Required = true },
+                new FieldDefinition { Name = "longField", Required = true },
+                new FieldDefinition { Name = "doubleField", Required = true },
+                new FieldDefinition { Name = "boolField", Required = true },
+                new FieldDefinition { Name = "dateField", Required = true },
+                new FieldDefinition { Name = "durationField", Required = true },
+                new FieldDefinition { Name = "guidField", Required = true },
+                new FieldDefinition { Name = "strArrayField", Required = true },
+                new FieldDefinition { Name = "intArrayField", Required = true },
+                new FieldDefinition { Name = "mapField", Required = true }
             ]
         });
 
@@ -357,16 +357,16 @@ public class CodeGeneratorTests
         var content = files.First(f => f.FileName.Contains("Events")).Content;
 
         Assert.Contains("string strField", content);
-        Assert.Contains("int intField", content);
-        Assert.Contains("long longField", content);
-        Assert.Contains("double doubleField", content);
-        Assert.Contains("bool boolField", content);
-        Assert.Contains("DateTimeOffset dateField", content);
-        Assert.Contains("TimeSpan durationField", content);
-        Assert.Contains("Guid guidField", content);
-        Assert.Contains("string[] strArrayField", content);
-        Assert.Contains("int[] intArrayField", content);
-        Assert.Contains("Dictionary<string, string> mapField", content);
+        Assert.Contains("string intField", content);
+        Assert.Contains("string longField", content);
+        Assert.Contains("string doubleField", content);
+        Assert.Contains("string boolField", content);
+        Assert.Contains("string dateField", content);
+        Assert.Contains("string durationField", content);
+        Assert.Contains("string guidField", content);
+        Assert.Contains("string strArrayField", content);
+        Assert.Contains("string intArrayField", content);
+        Assert.Contains("string mapField", content);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -523,7 +523,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }],
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }],
             Metrics = [new MetricDefinition { Name = "order.placed.count", Type = MetricType.Counter }]
         });
 
@@ -543,7 +543,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }],
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }],
             Metrics = [new MetricDefinition { Name = "order.placed.count", Type = MetricType.Counter }]
         });
 
@@ -582,8 +582,8 @@ public class CodeGeneratorTests
             Message = "Order {orderId} placed for {amount}",
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = true }
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "amount", Required = true }
             ],
             Metrics = [new MetricDefinition { Name = "order.placed.amount", Type = MetricType.Histogram }]
         });
@@ -607,8 +607,8 @@ public class CodeGeneratorTests
             Message = "Order {orderId} placed",
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "region", Type = FieldType.String, Required = true }
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "region", Required = true }
             ],
             Metrics = [new MetricDefinition
             {
@@ -634,7 +634,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }]
         });
 
         var files = _generator.GenerateFromSchema(doc);
@@ -781,7 +781,7 @@ public class CodeGeneratorTests
     }
 
     [Fact]
-    public void Generate_InlineEnum_GeneratesEnumFile()
+    public void Generate_StringField_DoesNotGenerateEnumFile()
     {
         var doc = CreateSchemaWithEvent(new EventDefinition
         {
@@ -794,8 +794,6 @@ public class CodeGeneratorTests
                 new FieldDefinition
                 {
                     Name = "method",
-                    Type = FieldType.Enum,
-                    Values = ["GET", "POST", "PUT", "DELETE"],
                     Required = true
                 }
             ]
@@ -803,7 +801,8 @@ public class CodeGeneratorTests
 
         var files = _generator.GenerateFromSchema(doc);
 
-        Assert.Contains(files, f => f.FileName.Contains("Method") && f.Content.Contains("public enum Method"));
+        // String fields do not generate separate enum files
+        Assert.DoesNotContain(files, f => f.FileName.Contains("Method") && f.Content.Contains("public enum Method"));
     }
 
     [Fact]
@@ -819,8 +818,8 @@ public class CodeGeneratorTests
             },
             Enums =
             [
-                new EnumDefinition { Name = "color", Values = ["Red", "Green", "Blue"] },
-                new EnumDefinition { Name = "size", Values = ["Small", "Medium", "Large"] }
+                new EnumDefinition { Name = "color", Values = ["Red", "Blue"] },
+                new EnumDefinition { Name = "size", Values = ["Small", "Large"] }
             ]
         };
 
@@ -872,7 +871,7 @@ public class CodeGeneratorTests
             },
             Enums =
             [
-                new EnumDefinition { Name = "order_status", Values = ["Pending", "Completed", "Failed"] }
+                new EnumDefinition { Name = "order_status", Values = ["Pending", "Completed", "Cancelled"] }
             ],
             Events =
             [
@@ -884,10 +883,10 @@ public class CodeGeneratorTests
                     Message = "Order {orderId} placed by {userId} for {amount}",
                     Fields =
                     [
-                        new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                        new FieldDefinition { Name = "userId", Type = FieldType.String, Required = true },
-                        new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = true },
-                        new FieldDefinition { Name = "status", Type = FieldType.Enum, Ref = "order_status", Required = true }
+                        new FieldDefinition { Name = "orderId", Required = true },
+                        new FieldDefinition { Name = "userId", Required = true },
+                        new FieldDefinition { Name = "amount", Required = true },
+                        new FieldDefinition { Name = "status", Required = true }
                     ],
                     Metrics =
                     [
@@ -924,7 +923,7 @@ public class CodeGeneratorTests
 
         // Emit method
         Assert.Contains("EmitOrderPlaced", eventsFile.Content);
-        Assert.Contains("OrderStatus status", eventsFile.Content);
+        Assert.Contains("string status", eventsFile.Content);
 
         // Enum file
         Assert.Contains("public enum OrderStatus", enumFile.Content);
@@ -944,7 +943,7 @@ public class CodeGeneratorTests
             Id = 1001,
             Severity = Severity.Info,
             Message = "Order {orderId} placed",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "orderId", Required = true }]
         });
 
         var files = _generator.GenerateFromSchema(doc);
@@ -971,7 +970,7 @@ public class CodeGeneratorTests
             },
             Enums =
             [
-                new EnumDefinition { Name = "payment_method", Values = ["CreditCard", "DebitCard", "PayPal", "BankTransfer"] }
+                new EnumDefinition { Name = "payment_method", Values = ["CreditCard", "PayPal", "Crypto"] }
             ],
             Events =
             [
@@ -984,10 +983,10 @@ public class CodeGeneratorTests
                     Exception = false,
                     Fields =
                     [
-                        new FieldDefinition { Name = "paymentId", Type = FieldType.String, Required = true },
-                        new FieldDefinition { Name = "method", Type = FieldType.Enum, Ref = "payment_method", Required = true },
-                        new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = true },
-                        new FieldDefinition { Name = "currency", Type = FieldType.String, Required = false }
+                        new FieldDefinition { Name = "paymentId", Required = true },
+                        new FieldDefinition { Name = "method", Required = true },
+                        new FieldDefinition { Name = "amount", Required = true },
+                        new FieldDefinition { Name = "currency", Required = false }
                     ],
                     Metrics =
                     [
@@ -1011,8 +1010,8 @@ public class CodeGeneratorTests
                     Exception = true,
                     Fields =
                     [
-                        new FieldDefinition { Name = "paymentId", Type = FieldType.String, Required = true },
-                        new FieldDefinition { Name = "reason", Type = FieldType.String, Required = true }
+                        new FieldDefinition { Name = "paymentId", Required = true },
+                        new FieldDefinition { Name = "reason", Required = true }
                     ],
                     Metrics =
                     [
@@ -1043,8 +1042,8 @@ public class CodeGeneratorTests
             Message = "Order {orderId} placed",
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = true }
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "amount", Required = true }
             ],
             Metrics =
             [
@@ -1175,6 +1174,82 @@ public class CodeGeneratorTests
 
         Assert.DoesNotContain("TestServiceMetrics", content);
         Assert.DoesNotContain("new Meter(", content);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 11. STRING-ONLY FIELDS — ALL PARAMS ARE STRING
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Generate_AllFieldsAreStrings_NoMatterWhatYamlTypeSaid()
+    {
+        var doc = CreateSchemaWithEvent(new EventDefinition
+        {
+            Name = "test.strings",
+            Id = 8000,
+            Severity = Severity.Info,
+            Message = "Test {orderId} for {amount}",
+            Fields =
+            [
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "amount", Required = true },
+                new FieldDefinition { Name = "isActive", Required = false }
+            ]
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("string orderId", content);
+        Assert.Contains("string amount", content);
+        Assert.Contains("string? isActive", content);
+        Assert.DoesNotContain("double amount", content);
+        Assert.DoesNotContain("bool isActive", content);
+    }
+
+    [Fact]
+    public void Generate_HistogramMetric_UsesDoubleTryParse()
+    {
+        var doc = CreateSchemaWithEvent(new EventDefinition
+        {
+            Name = "order.placed",
+            Id = 1001,
+            Severity = Severity.Info,
+            Message = "Order {orderId} for {amount}",
+            Fields =
+            [
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "amount", Required = true }
+            ],
+            Metrics = [new MetricDefinition { Name = "order.placed.amount", Type = MetricType.Histogram }]
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        // Should use double.TryParse since amount is a string but histogram needs double
+        Assert.Contains("double.TryParse(amount", content);
+        Assert.Contains("amountValue", content);
+        Assert.Contains(".Record(amountValue", content);
+    }
+
+    [Fact]
+    public void Generate_HistogramMetric_NoMatchingField_RecordsDefault()
+    {
+        var doc = CreateSchemaWithEvent(new EventDefinition
+        {
+            Name = "order.placed",
+            Id = 1001,
+            Severity = Severity.Info,
+            Message = "Order placed",
+            Metrics = [new MetricDefinition { Name = "order.placed.duration", Type = MetricType.Histogram }]
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        // No matching field named 'duration', should fall back to Record(1)
+        Assert.Contains(".Record(1", content);
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/tests/OtelEvents.Schema.Tests/Documentation/SchemaDocumentationGeneratorTests.cs
+++ b/tests/OtelEvents.Schema.Tests/Documentation/SchemaDocumentationGeneratorTests.cs
@@ -271,8 +271,8 @@ public class SchemaDocumentationGeneratorTests
             Message = "Order {orderId} placed",
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = false }
+                new FieldDefinition { Name = "orderId", Required = true },
+                new FieldDefinition { Name = "amount", Required = false }
             ]
         });
 
@@ -282,7 +282,6 @@ public class SchemaDocumentationGeneratorTests
         Assert.Contains("orderId", markdown);
         Assert.Contains("string", markdown);
         Assert.Contains("amount", markdown);
-        Assert.Contains("double", markdown);
     }
 
     [Fact]
@@ -294,7 +293,7 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "f1", Type = FieldType.String, Required = true }]
+            Fields = [new FieldDefinition { Name = "f1", Required = true }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
@@ -311,7 +310,7 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "f1", Type = FieldType.String, Required = false }]
+            Fields = [new FieldDefinition { Name = "f1", Required = false }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
@@ -331,7 +330,7 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "email", Type = FieldType.String, Sensitivity = Sensitivity.Pii }]
+            Fields = [new FieldDefinition { Name = "email", Sensitivity = Sensitivity.Pii }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
@@ -348,7 +347,7 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "status", Type = FieldType.String, Sensitivity = Sensitivity.Public }]
+            Fields = [new FieldDefinition { Name = "status", Sensitivity = Sensitivity.Public }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
@@ -367,7 +366,7 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "orderId", Type = FieldType.String, Description = "Unique order identifier" }]
+            Fields = [new FieldDefinition { Name = "orderId", Description = "Unique order identifier" }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
@@ -376,7 +375,7 @@ public class SchemaDocumentationGeneratorTests
     }
 
     [Fact]
-    public void GenerateMarkdown_FieldWithUnit_IncludesUnit()
+    public void GenerateMarkdown_FieldWithDescription_IncludesFieldDescription()
     {
         var doc = CreateSchemaWithEvent(new EventDefinition
         {
@@ -384,12 +383,12 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "duration", Type = FieldType.Double, Unit = "ms" }]
+            Fields = [new FieldDefinition { Name = "duration", Description = "Duration in milliseconds" }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
 
-        Assert.Contains("ms", markdown);
+        Assert.Contains("Duration in milliseconds", markdown);
     }
 
     [Fact]
@@ -409,7 +408,7 @@ public class SchemaDocumentationGeneratorTests
     }
 
     [Fact]
-    public void GenerateMarkdown_FieldWithEnumRef_ShowsEnumRef()
+    public void GenerateMarkdown_FieldWithStringType_ShowsStringType()
     {
         var doc = CreateSchemaWithEvent(new EventDefinition
         {
@@ -417,12 +416,13 @@ public class SchemaDocumentationGeneratorTests
             Id = 1,
             Severity = Severity.Info,
             Message = "msg",
-            Fields = [new FieldDefinition { Name = "status", Type = FieldType.Enum, Ref = "OrderStatus" }]
+            Fields = [new FieldDefinition { Name = "status" }]
         });
 
         var markdown = _generator.GenerateMarkdown(doc);
 
-        Assert.Contains("OrderStatus", markdown);
+        Assert.Contains("status", markdown);
+        Assert.Contains("string", markdown);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -602,7 +602,7 @@ public class SchemaDocumentationGeneratorTests
             Enums =
             [
                 new EnumDefinition { Name = "Status", Values = ["Active", "Inactive"] },
-                new EnumDefinition { Name = "Priority", Values = ["Low", "Medium", "High"] }
+                new EnumDefinition { Name = "Priority", Values = ["Low", "High"] }
             ]
         };
 
@@ -634,8 +634,8 @@ public class SchemaDocumentationGeneratorTests
             Schema = new SchemaHeader { Name = "Test", Version = "1.0.0", Namespace = "Test.Events" },
             Fields =
             [
-                new FieldDefinition { Name = "requestId", Type = FieldType.String, Description = "Unique request identifier" },
-                new FieldDefinition { Name = "durationMs", Type = FieldType.Double, Unit = "ms", Description = "Duration in ms" }
+                new FieldDefinition { Name = "requestId", Description = "Unique request identifier" },
+                new FieldDefinition { Name = "durationMs", Description = "Duration in ms" }
             ]
         };
 
@@ -674,7 +674,7 @@ public class SchemaDocumentationGeneratorTests
             },
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String, Description = "Unique order identifier" }
+                new FieldDefinition { Name = "orderId", Description = "Unique order identifier" }
             ],
             Enums =
             [
@@ -696,9 +696,9 @@ public class SchemaDocumentationGeneratorTests
                     Message = "Order {orderId} placed for {amount}",
                     Fields =
                     [
-                        new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                        new FieldDefinition { Name = "amount", Type = FieldType.Double, Required = true, Unit = "USD" },
-                        new FieldDefinition { Name = "customerEmail", Type = FieldType.String, Sensitivity = Sensitivity.Pii }
+                        new FieldDefinition { Name = "orderId", Required = true },
+                        new FieldDefinition { Name = "amount", Required = true },
+                        new FieldDefinition { Name = "customerEmail", Sensitivity = Sensitivity.Pii }
                     ],
                     Metrics =
                     [
@@ -717,8 +717,8 @@ public class SchemaDocumentationGeneratorTests
                     Exception = true,
                     Fields =
                     [
-                        new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true },
-                        new FieldDefinition { Name = "reason", Type = FieldType.String, Required = true }
+                        new FieldDefinition { Name = "orderId", Required = true },
+                        new FieldDefinition { Name = "reason", Required = true }
                     ],
                     Tags = ["order", "error"]
                 }
@@ -792,7 +792,7 @@ public class SchemaDocumentationGeneratorTests
         var doc = new SchemaDocument
         {
             Schema = new SchemaHeader { Name = "Test", Version = "1.0.0", Namespace = "Test.Events" },
-            Enums = [new EnumDefinition { Name = "HealthStatus", Values = ["Healthy", "Degraded", "Unhealthy"] }],
+            Enums = [new EnumDefinition { Name = "HealthStatus", Values = ["Healthy", "Unhealthy"] }],
             Events =
             [
                 new EventDefinition
@@ -801,15 +801,15 @@ public class SchemaDocumentationGeneratorTests
                     Id = 1,
                     Severity = Severity.Warn,
                     Message = "Health changed to {status}",
-                    Fields = [new FieldDefinition { Name = "status", Type = FieldType.Enum, Ref = "HealthStatus", Required = true }]
+                    Fields = [new FieldDefinition { Name = "status", Required = true }]
                 }
             ]
         };
 
         var markdown = _generator.GenerateMarkdown(doc);
 
-        // Should reference the enum type
-        Assert.Contains("enum (HealthStatus)", markdown);
+        // All fields are now strings
+        Assert.Contains("string", markdown);
     }
 
     [Fact]
@@ -817,17 +817,17 @@ public class SchemaDocumentationGeneratorTests
     {
         var fields = new List<FieldDefinition>
         {
-            new() { Name = "f1", Type = FieldType.String },
-            new() { Name = "f2", Type = FieldType.Int },
-            new() { Name = "f3", Type = FieldType.Long },
-            new() { Name = "f4", Type = FieldType.Double },
-            new() { Name = "f5", Type = FieldType.Bool },
-            new() { Name = "f6", Type = FieldType.DateTime },
-            new() { Name = "f7", Type = FieldType.Duration },
-            new() { Name = "f8", Type = FieldType.Guid },
-            new() { Name = "f9", Type = FieldType.StringArray },
-            new() { Name = "f10", Type = FieldType.IntArray },
-            new() { Name = "f11", Type = FieldType.Map }
+            new() { Name = "f1" },
+            new() { Name = "f2" },
+            new() { Name = "f3" },
+            new() { Name = "f4" },
+            new() { Name = "f5" },
+            new() { Name = "f6" },
+            new() { Name = "f7" },
+            new() { Name = "f8" },
+            new() { Name = "f9" },
+            new() { Name = "f10" },
+            new() { Name = "f11" }
         };
 
         var doc = CreateSchemaWithEvent(new EventDefinition
@@ -843,16 +843,6 @@ public class SchemaDocumentationGeneratorTests
 
         Assert.Contains("| f1 ", markdown);
         Assert.Contains("string", markdown);
-        Assert.Contains("int", markdown);
-        Assert.Contains("long", markdown);
-        Assert.Contains("double", markdown);
-        Assert.Contains("bool", markdown);
-        Assert.Contains("datetime", markdown);
-        Assert.Contains("duration", markdown);
-        Assert.Contains("guid", markdown);
-        Assert.Contains("string[]", markdown);
-        Assert.Contains("int[]", markdown);
-        Assert.Contains("map", markdown);
     }
 
     [Fact]
@@ -893,10 +883,10 @@ public class SchemaDocumentationGeneratorTests
             Message = "msg",
             Fields =
             [
-                new FieldDefinition { Name = "f1", Type = FieldType.String, Sensitivity = Sensitivity.Public },
-                new FieldDefinition { Name = "f2", Type = FieldType.String, Sensitivity = Sensitivity.Internal },
-                new FieldDefinition { Name = "f3", Type = FieldType.String, Sensitivity = Sensitivity.Pii },
-                new FieldDefinition { Name = "f4", Type = FieldType.String, Sensitivity = Sensitivity.Credential }
+                new FieldDefinition { Name = "f1", Sensitivity = Sensitivity.Public },
+                new FieldDefinition { Name = "f2", Sensitivity = Sensitivity.Internal },
+                new FieldDefinition { Name = "f3", Sensitivity = Sensitivity.Pii },
+                new FieldDefinition { Name = "f4", Sensitivity = Sensitivity.Credential }
             ]
         });
 

--- a/tests/OtelEvents.Schema.Tests/LifecycleSchemaTests.cs
+++ b/tests/OtelEvents.Schema.Tests/LifecycleSchemaTests.cs
@@ -190,12 +190,9 @@ public class LifecycleSchemaTests
         Assert.Equal(2, evt.Fields.Count);
 
         var phaseField = evt.Fields.First(f => f.Name == "phase");
-        Assert.Equal(FieldType.Enum, phaseField.Type);
-        Assert.Equal("LifecyclePhase", phaseField.Ref);
         Assert.True(phaseField.Required);
 
         var reasonField = evt.Fields.First(f => f.Name == "reason");
-        Assert.Equal(FieldType.String, reasonField.Type);
         Assert.False(reasonField.Required);
     }
 
@@ -210,13 +207,9 @@ public class LifecycleSchemaTests
         Assert.Equal(3, evt.Fields.Count);
 
         var prevField = evt.Fields.First(f => f.Name == "previousStatus");
-        Assert.Equal(FieldType.Enum, prevField.Type);
-        Assert.Equal("HealthStatus", prevField.Ref);
         Assert.True(prevField.Required);
 
         var currField = evt.Fields.First(f => f.Name == "currentStatus");
-        Assert.Equal(FieldType.Enum, currField.Type);
-        Assert.Equal("HealthStatus", currField.Ref);
         Assert.True(currField.Required);
     }
 
@@ -232,7 +225,6 @@ public class LifecycleSchemaTests
 
         var durationField = evt.Fields[0];
         Assert.Equal("durationMs", durationField.Name);
-        Assert.Equal(FieldType.Long, durationField.Type);
         Assert.True(durationField.Required);
     }
 
@@ -248,7 +240,6 @@ public class LifecycleSchemaTests
 
         var reasonField = evt.Fields[0];
         Assert.Equal("reason", reasonField.Name);
-        Assert.Equal(FieldType.String, reasonField.Type);
         Assert.True(reasonField.Required);
     }
 
@@ -391,8 +382,8 @@ public class LifecycleSchemaTests
         var files = _generator.GenerateFromSchema(doc);
         var content = files.First(f => f.FileName.Contains("Events")).Content;
 
-        Assert.Contains("HealthStatus previousStatus", content);
-        Assert.Contains("HealthStatus currentStatus", content);
+        Assert.Contains("string previousStatus", content);
+        Assert.Contains("string currentStatus", content);
     }
 
     [Fact]
@@ -402,7 +393,7 @@ public class LifecycleSchemaTests
         var files = _generator.GenerateFromSchema(doc);
         var content = files.First(f => f.FileName.Contains("Events")).Content;
 
-        Assert.Contains("LifecyclePhase phase", content);
+        Assert.Contains("string phase", content);
     }
 
     [Fact]
@@ -412,7 +403,7 @@ public class LifecycleSchemaTests
         var files = _generator.GenerateFromSchema(doc);
         var content = files.First(f => f.FileName.Contains("Events")).Content;
 
-        Assert.Contains("long durationMs", content);
+        Assert.Contains("string durationMs", content);
     }
 
     [Fact]

--- a/tests/OtelEvents.Schema.Tests/OtelEvents.Schema.Tests.csproj
+++ b/tests/OtelEvents.Schema.Tests/OtelEvents.Schema.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NoWarn>CA1307;CA1310;CA1707</NoWarn>
+    <NoWarn>CA1307;CA1310;CA1707;CS0612;CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/OtelEvents.Schema.Tests/SchemaComparerTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaComparerTests.cs
@@ -20,7 +20,7 @@ public class SchemaComparerTests
     {
         var schema = CreateSchema(events:
         [
-            CreateEvent("http.request", 1, fields: [CreateField("method", FieldType.String)])
+            CreateEvent("http.request", 1, fields: [CreateField("method")])
         ]);
 
         var result = _comparer.Compare(schema, schema);
@@ -107,7 +107,7 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String)
+                CreateField("method")
             ])
         ]);
 
@@ -115,8 +115,8 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String),
-                CreateField("path", FieldType.String)
+                CreateField("method"),
+                CreateField("path")
             ])
         ]);
 
@@ -137,8 +137,8 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String),
-                CreateField("path", FieldType.String)
+                CreateField("method"),
+                CreateField("path")
             ])
         ]);
 
@@ -146,7 +146,7 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String)
+                CreateField("method")
             ])
         ]);
 
@@ -160,13 +160,14 @@ public class SchemaComparerTests
     }
 
     [Fact]
-    public void Compare_FieldTypeChanged_ReportsBreakingChange()
+    public void Compare_FieldsSame_NoChanges()
     {
+        // All fields are strings now, so same-name fields are always equal
         var oldSchema = CreateSchema(events:
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("statusCode", FieldType.String)
+                CreateField("statusCode")
             ])
         ]);
 
@@ -174,17 +175,13 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("statusCode", FieldType.Int)
+                CreateField("statusCode")
             ])
         ]);
 
         var result = _comparer.Compare(oldSchema, newSchema);
 
-        Assert.Single(result.Changes);
-        var change = result.Changes[0];
-        Assert.Equal(SchemaChangeKind.FieldTypeChanged, change.Kind);
-        Assert.Contains("statusCode", change.Name);
-        Assert.True(change.IsBreaking);
+        Assert.Empty(result.Changes);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -203,7 +200,7 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String)
+                CreateField("method")
             ]),
             CreateEvent("http.response", 2)
         ]);
@@ -220,7 +217,7 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String)
+                CreateField("method")
             ]),
             CreateEvent("http.response", 2)
         ]);
@@ -229,8 +226,8 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String),
-                CreateField("path", FieldType.String) // added, non-breaking
+                CreateField("method"),
+                CreateField("path") // added, non-breaking
             ])
             // http.response removed — breaking
         ]);
@@ -273,7 +270,7 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String)
+                CreateField("method")
             ])
         ]);
 
@@ -281,7 +278,8 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.Int) // type changed
+                CreateField("method"),
+                CreateField("path") // field added
             ])
         ]);
 
@@ -289,8 +287,6 @@ public class SchemaComparerTests
         var change = result.Changes[0];
 
         Assert.NotEmpty(change.Description);
-        Assert.Contains("string", change.Description, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("int", change.Description, StringComparison.OrdinalIgnoreCase);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -305,7 +301,7 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String)
+                CreateField("method")
             ])
         ]);
 
@@ -340,8 +336,8 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String),
-                CreateField("oldField", FieldType.String)
+                CreateField("method"),
+                CreateField("oldField")
             ])
         ]);
 
@@ -349,8 +345,8 @@ public class SchemaComparerTests
         [
             CreateEvent("http.request", 1, fields:
             [
-                CreateField("method", FieldType.String),
-                CreateField("newField", FieldType.String)
+                CreateField("method"),
+                CreateField("newField")
             ])
         ]);
 
@@ -390,10 +386,8 @@ public class SchemaComparerTests
     };
 
     private static FieldDefinition CreateField(
-        string name,
-        FieldType type) => new()
+        string name) => new()
     {
-        Name = name,
-        Type = type
+        Name = name
     };
 }

--- a/tests/OtelEvents.Schema.Tests/SchemaMergerTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaMergerTests.cs
@@ -110,7 +110,7 @@ public class SchemaMergerTests
             },
             Fields =
             [
-                new FieldDefinition { Name = "userId", Type = FieldType.String }
+                new FieldDefinition { Name = "userId" }
             ],
             Enums =
             [
@@ -128,7 +128,7 @@ public class SchemaMergerTests
             },
             Fields =
             [
-                new FieldDefinition { Name = "orderId", Type = FieldType.String }
+                new FieldDefinition { Name = "orderId" }
             ]
         };
 

--- a/tests/OtelEvents.Schema.Tests/SchemaParserTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaParserTests.cs
@@ -102,17 +102,11 @@ public class SchemaParserTests
 
         var userId = result.Document.Fields[0];
         Assert.Equal("userId", userId.Name);
-        Assert.Equal(FieldType.String, userId.Type);
         Assert.Equal("Unique user identifier", userId.Description);
         Assert.True(userId.Index);
-        Assert.NotNull(userId.Examples);
-        Assert.Single(userId.Examples);
-        Assert.Equal("usr_abc123", userId.Examples[0]);
 
         var duration = result.Document.Fields[1];
         Assert.Equal("durationMs", duration.Name);
-        Assert.Equal(FieldType.Double, duration.Type);
-        Assert.Equal("ms", duration.Unit);
     }
 
     [Fact]
@@ -191,7 +185,7 @@ public class SchemaParserTests
     }
 
     [Fact]
-    public void Parse_EventWithRefField_ParsesRef()
+    public void Parse_EventWithRefField_StillParsesSuccessfully()
     {
         var yaml = """
             schema:
@@ -218,7 +212,6 @@ public class SchemaParserTests
         Assert.True(result.IsSuccess);
         var field = result.Document!.Events[0].Fields[0];
         Assert.Equal("method", field.Name);
-        Assert.Equal("httpMethod", field.Ref);
         Assert.True(field.Required);
     }
 
@@ -374,7 +367,7 @@ public class SchemaParserTests
     }
 
     [Fact]
-    public void Parse_AllFieldTypes_ParsesCorrectly()
+    public void Parse_AllFieldTypes_BackwardCompatible()
     {
         var yaml = """
             schema:
@@ -419,18 +412,6 @@ public class SchemaParserTests
         Assert.True(result.IsSuccess);
         var fields = result.Document!.Events[0].Fields;
         Assert.Equal(12, fields.Count);
-        Assert.Equal(FieldType.String, fields[0].Type);
-        Assert.Equal(FieldType.Int, fields[1].Type);
-        Assert.Equal(FieldType.Long, fields[2].Type);
-        Assert.Equal(FieldType.Double, fields[3].Type);
-        Assert.Equal(FieldType.Bool, fields[4].Type);
-        Assert.Equal(FieldType.DateTime, fields[5].Type);
-        Assert.Equal(FieldType.Duration, fields[6].Type);
-        Assert.Equal(FieldType.Guid, fields[7].Type);
-        Assert.Equal(FieldType.Enum, fields[8].Type);
-        Assert.Equal(FieldType.StringArray, fields[9].Type);
-        Assert.Equal(FieldType.IntArray, fields[10].Type);
-        Assert.Equal(FieldType.Map, fields[11].Type);
     }
 
     [Fact]
@@ -551,7 +532,7 @@ public class SchemaParserTests
     }
 
     [Fact]
-    public void Parse_FieldWithInlineEnumValues_ParsesValues()
+    public void Parse_FieldWithInlineEnumValues_StillParsesSuccessfully()
     {
         var yaml = """
             schema:
@@ -577,10 +558,8 @@ public class SchemaParserTests
 
         Assert.True(result.IsSuccess);
         var opField = result.Document!.Events[0].Fields[1];
-        Assert.Equal(FieldType.Enum, opField.Type);
-        Assert.NotNull(opField.Values);
-        Assert.Equal(4, opField.Values.Count);
-        Assert.Contains("SELECT", opField.Values);
+        Assert.Equal("operation", opField.Name);
+        Assert.True(opField.Required);
     }
 
     [Fact]
@@ -655,5 +634,193 @@ public class SchemaParserTests
         Assert.Equal(2, evt.Fields.Count);
         Assert.Single(evt.Metrics);
         Assert.Equal(2, evt.Tags.Count);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // SHORTHAND LIST SYNTAX FOR FIELDS (new in Issue #42)
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_EventFieldsAsSequence_SimpleNames_ParsesCorrectly()
+    {
+        var yaml = """
+            schema:
+              name: "TestService"
+              version: "1.0.0"
+              namespace: "Test.Namespace"
+            events:
+              order.placed:
+                id: 1001
+                severity: INFO
+                message: "Order {orderId} placed"
+                fields:
+                  - orderId
+                  - customerId
+                  - amount
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        var fields = result.Document!.Events[0].Fields;
+        Assert.Equal(3, fields.Count);
+        Assert.Equal("orderId", fields[0].Name);
+        Assert.Equal("customerId", fields[1].Name);
+        Assert.Equal("amount", fields[2].Name);
+    }
+
+    [Fact]
+    public void Parse_EventFieldsAsSequence_WithAnnotations_ParsesCorrectly()
+    {
+        var yaml = """
+            schema:
+              name: "TestService"
+              version: "1.0.0"
+              namespace: "Test.Namespace"
+            events:
+              user.login:
+                id: 2001
+                severity: INFO
+                message: "User {userId} logged in"
+                fields:
+                  - userId: { sensitivity: pii, required: true }
+                  - email: { sensitivity: pii }
+                  - region
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        var fields = result.Document!.Events[0].Fields;
+        Assert.Equal(3, fields.Count);
+
+        Assert.Equal("userId", fields[0].Name);
+        Assert.Equal(Sensitivity.Pii, fields[0].Sensitivity);
+        Assert.True(fields[0].Required);
+
+        Assert.Equal("email", fields[1].Name);
+        Assert.Equal(Sensitivity.Pii, fields[1].Sensitivity);
+        Assert.False(fields[1].Required);
+
+        Assert.Equal("region", fields[2].Name);
+        Assert.Equal(Sensitivity.Public, fields[2].Sensitivity);
+    }
+
+    [Fact]
+    public void Parse_SharedFieldsAsSequence_ParsesCorrectly()
+    {
+        var yaml = """
+            schema:
+              name: "TestService"
+              version: "1.0.0"
+              namespace: "Test.Namespace"
+            fields:
+              - orderId
+              - customerId: { sensitivity: pii }
+              - amount: { required: true }
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        var fields = result.Document!.Fields;
+        Assert.Equal(3, fields.Count);
+        Assert.Equal("orderId", fields[0].Name);
+        Assert.Equal("customerId", fields[1].Name);
+        Assert.Equal(Sensitivity.Pii, fields[1].Sensitivity);
+        Assert.Equal("amount", fields[2].Name);
+        Assert.True(fields[2].Required);
+    }
+
+    [Fact]
+    public void Parse_OldMapSyntaxWithType_StillParsesSuccessfully()
+    {
+        // Backward compat: old type: key is silently accepted but ignored
+        var yaml = """
+            schema:
+              name: "TestService"
+              version: "1.0.0"
+              namespace: "Test.Namespace"
+            events:
+              order.placed:
+                id: 1001
+                severity: INFO
+                message: "Order {orderId} for {amount}"
+                fields:
+                  orderId:
+                    type: string
+                    required: true
+                  amount:
+                    type: double
+                    required: true
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        var fields = result.Document!.Events[0].Fields;
+        Assert.Equal(2, fields.Count);
+        Assert.Equal("orderId", fields[0].Name);
+        Assert.True(fields[0].Required);
+        Assert.Equal("amount", fields[1].Name);
+        Assert.True(fields[1].Required);
+    }
+
+    [Fact]
+    public void Parse_OldMapSyntaxWithRef_StillParsesSuccessfully()
+    {
+        // Backward compat: old ref: key is silently accepted but ignored
+        var yaml = """
+            schema:
+              name: "TestService"
+              version: "1.0.0"
+              namespace: "Test.Namespace"
+            fields:
+              userId:
+                type: string
+                description: "User ID"
+            events:
+              test.event:
+                id: 1
+                severity: INFO
+                message: "User {method}"
+                fields:
+                  method:
+                    ref: userId
+                    required: true
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        var field = result.Document!.Events[0].Fields[0];
+        Assert.Equal("method", field.Name);
+        Assert.True(field.Required);
+    }
+
+    [Fact]
+    public void Parse_FieldWithMaxLengthInSequence_ParsesCorrectly()
+    {
+        var yaml = """
+            schema:
+              name: "TestService"
+              version: "1.0.0"
+              namespace: "Test.Namespace"
+            events:
+              test.event:
+                id: 1
+                severity: INFO
+                message: "Path {path}"
+                fields:
+                  - path: { required: true, maxLength: 256 }
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        var field = result.Document!.Events[0].Fields[0];
+        Assert.Equal("path", field.Name);
+        Assert.True(field.Required);
+        Assert.Equal(256, field.MaxLength);
     }
 }

--- a/tests/OtelEvents.Schema.Tests/SchemaValidatorTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaValidatorTests.cs
@@ -125,7 +125,7 @@ public class SchemaValidatorTests
     // ── OTEL_SCHEMA_004: Ref resolution ──────────────────────────────────
 
     [Fact]
-    public void Validate_UnresolvedRef_ReturnsOTEL_SCHEMA_004()
+    public void Validate_UnresolvedRef_AcceptedSilently()
     {
         var yaml = """
             schema:
@@ -145,8 +145,8 @@ public class SchemaValidatorTests
 
         var result = ParseAndValidate(yaml);
 
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Code == ErrorCodes.UnresolvedRef);
+        // Ref resolution is no longer validated (refs are silently ignored)
+        Assert.DoesNotContain(result.Errors, e => e.Code == ErrorCodes.UnresolvedRef);
     }
 
     [Fact]
@@ -210,7 +210,7 @@ public class SchemaValidatorTests
     // ── OTEL_SCHEMA_005: Type validity ───────────────────────────────────
 
     [Fact]
-    public void Validate_InvalidFieldType_ReturnsOTEL_SCHEMA_005()
+    public void Validate_UnknownFieldType_AcceptedSilently()
     {
         var yaml = """
             schema:
@@ -230,8 +230,8 @@ public class SchemaValidatorTests
 
         var result = ParseAndValidate(yaml);
 
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Code == ErrorCodes.InvalidType);
+        // Invalid field types are silently accepted (all fields are strings now)
+        Assert.DoesNotContain(result.Errors, e => e.Code == ErrorCodes.InvalidType);
     }
 
     // ── OTEL_SCHEMA_006: Event name format ───────────────────────────────
@@ -275,7 +275,7 @@ public class SchemaValidatorTests
     // ── OTEL_SCHEMA_007: Required field completeness ─────────────────────
 
     [Fact]
-    public void Validate_RequiredFieldWithoutTypeOrRef_ReturnsOTEL_SCHEMA_007()
+    public void Validate_RequiredFieldWithoutType_AcceptedSilently()
     {
         var yaml = """
             schema:
@@ -294,8 +294,8 @@ public class SchemaValidatorTests
 
         var result = ParseAndValidate(yaml);
 
-        Assert.False(result.IsValid);
-        Assert.Contains(result.Errors, e => e.Code == ErrorCodes.RequiredFieldMissingType);
+        // Required fields no longer need a type (all fields are strings)
+        Assert.DoesNotContain(result.Errors, e => e.Code == ErrorCodes.RequiredFieldMissingType);
     }
 
     // ── OTEL_SCHEMA_008: Metric type validity ────────────────────────────
@@ -715,7 +715,7 @@ public class SchemaValidatorTests
         var fields = new List<FieldDefinition>();
         for (int i = 0; i < 51; i++)
         {
-            fields.Add(new FieldDefinition { Name = $"field{i}", Type = FieldType.String });
+            fields.Add(new FieldDefinition { Name = $"field{i}" });
         }
 
         var doc = CreateMinimalDoc(events:
@@ -742,7 +742,7 @@ public class SchemaValidatorTests
         var fields = new List<FieldDefinition>();
         for (int i = 0; i < 50; i++)
         {
-            fields.Add(new FieldDefinition { Name = $"field{i}", Type = FieldType.String });
+            fields.Add(new FieldDefinition { Name = $"field{i}" });
         }
 
         var doc = CreateMinimalDoc(events:
@@ -839,7 +839,7 @@ public class SchemaValidatorTests
             },
             Fields =
             [
-                new FieldDefinition { Name = "httpMethod", Type = FieldType.String }
+                new FieldDefinition { Name = "httpMethod" }
             ]
         };
 
@@ -861,7 +861,7 @@ public class SchemaValidatorTests
                     Message = "Request {method}",
                     Fields =
                     [
-                        new FieldDefinition { Name = "method", Ref = "httpMethod", Required = true }
+                        new FieldDefinition { Name = "method", Required = true }
                     ]
                 }
             ]

--- a/tests/OtelEvents.Schema.Tests/SecurityAndFieldTypeTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SecurityAndFieldTypeTests.cs
@@ -232,10 +232,10 @@ public class SecurityAndFieldTypeTests
         var fields = result.Document!.Events[0].Fields;
 
         var tagsField = fields.First(f => f.Name == "tags");
-        Assert.Equal(FieldType.StringArray, tagsField.Type);
+        Assert.Equal("Tags for categorization", tagsField.Description);
 
         var scoresField = fields.First(f => f.Name == "scores");
-        Assert.Equal(FieldType.IntArray, scoresField.Type);
+        Assert.Equal("Numeric scores", scoresField.Description);
     }
 
     [Fact]
@@ -257,8 +257,8 @@ public class SecurityAndFieldTypeTests
         Assert.True(result.IsSuccess);
         var fields = result.Document!.Fields;
 
-        Assert.Equal(FieldType.StringArray, fields.First(f => f.Name == "tags").Type);
-        Assert.Equal(FieldType.IntArray, fields.First(f => f.Name == "ids").Type);
+        Assert.Contains(fields, f => f.Name == "tags");
+        Assert.Contains(fields, f => f.Name == "ids");
     }
 
     // ── Map Field Type ──────────────────────────────────────────────────
@@ -286,7 +286,7 @@ public class SecurityAndFieldTypeTests
 
         Assert.True(result.IsSuccess);
         var field = result.Document!.Events[0].Fields.First(f => f.Name == "metadata");
-        Assert.Equal(FieldType.Map, field.Type);
+        Assert.Equal("Key-value metadata", field.Description);
     }
 
     [Fact]
@@ -304,6 +304,6 @@ public class SecurityAndFieldTypeTests
         var result = _parser.Parse(yaml, yaml.Length);
 
         Assert.True(result.IsSuccess);
-        Assert.Equal(FieldType.Map, result.Document!.Fields.First(f => f.Name == "headers").Type);
+        Assert.Contains(result.Document!.Fields, f => f.Name == "headers");
     }
 }

--- a/tests/OtelEvents.Schema.Tests/TypeMapperTests.cs
+++ b/tests/OtelEvents.Schema.Tests/TypeMapperTests.cs
@@ -4,35 +4,36 @@ using OtelEvents.Schema.Models;
 namespace OtelEvents.Schema.Tests;
 
 /// <summary>
-/// Tests for TypeMapper — validates YAML-to-C# type mapping
-/// and severity-to-LogLevel mapping.
+/// Tests for TypeMapper — validates that all fields map to "string"
+/// and severity-to-LogLevel mapping works correctly.
 /// </summary>
 public class TypeMapperTests
 {
-    // ── C# Type Mapping ────────────────────────────────────────────
+    // ── All Fields Are Strings ─────────────────────────────────────
 
-    [Theory]
-    [InlineData(FieldType.String, "string")]
-    [InlineData(FieldType.Int, "int")]
-    [InlineData(FieldType.Long, "long")]
-    [InlineData(FieldType.Double, "double")]
-    [InlineData(FieldType.Bool, "bool")]
-    [InlineData(FieldType.DateTime, "DateTimeOffset")]
-    [InlineData(FieldType.Duration, "TimeSpan")]
-    [InlineData(FieldType.Guid, "Guid")]
-    [InlineData(FieldType.StringArray, "string[]")]
-    [InlineData(FieldType.IntArray, "int[]")]
-    [InlineData(FieldType.Map, "Dictionary<string, string>")]
-    public void ToCSharpType_MapsAllFieldTypes(FieldType fieldType, string expected)
+    [Fact]
+    public void GetFieldCSharpType_AnyField_ReturnsString()
     {
-        Assert.Equal(expected, TypeMapper.ToCSharpType(fieldType));
+        var field = new FieldDefinition { Name = "amount" };
+        Assert.Equal("string", TypeMapper.GetFieldCSharpType(field));
     }
 
     [Fact]
-    public void ToCSharpType_EnumFieldType_ReturnsString()
+    public void GetFieldCSharpType_RequiredField_ReturnsString()
     {
-        // Enum base mapping returns "string"; actual enum type resolved via GetFieldCSharpType
-        Assert.Equal("string", TypeMapper.ToCSharpType(FieldType.Enum));
+        var field = new FieldDefinition { Name = "orderId", Required = true };
+        Assert.Equal("string", TypeMapper.GetFieldCSharpType(field));
+    }
+
+    [Fact]
+    public void GetFieldCSharpType_FieldWithSensitivity_ReturnsString()
+    {
+        var field = new FieldDefinition
+        {
+            Name = "userId",
+            Sensitivity = Sensitivity.Pii
+        };
+        Assert.Equal("string", TypeMapper.GetFieldCSharpType(field));
     }
 
     // ── Severity → LogLevel Mapping ────────────────────────────────
@@ -49,70 +50,6 @@ public class TypeMapperTests
         Assert.Equal(expected, TypeMapper.ToLogLevel(severity));
     }
 
-    // ── Field C# Type Resolution ───────────────────────────────────
-
-    [Fact]
-    public void GetFieldCSharpType_EnumWithRef_ReturnsPascalCaseRefName()
-    {
-        var field = new FieldDefinition
-        {
-            Name = "method",
-            Type = FieldType.Enum,
-            Ref = "http_method"
-        };
-
-        Assert.Equal("HttpMethod", TypeMapper.GetFieldCSharpType(field));
-    }
-
-    [Fact]
-    public void GetFieldCSharpType_EnumWithInlineValues_ReturnsPascalCaseFieldName()
-    {
-        var field = new FieldDefinition
-        {
-            Name = "status",
-            Type = FieldType.Enum,
-            Values = ["active", "inactive", "pending"]
-        };
-
-        Assert.Equal("Status", TypeMapper.GetFieldCSharpType(field));
-    }
-
-    [Fact]
-    public void GetFieldCSharpType_EnumWithoutRefOrValues_ReturnsString()
-    {
-        var field = new FieldDefinition
-        {
-            Name = "category",
-            Type = FieldType.Enum
-        };
-
-        Assert.Equal("string", TypeMapper.GetFieldCSharpType(field));
-    }
-
-    [Fact]
-    public void GetFieldCSharpType_NonEnumType_ReturnsMappedType()
-    {
-        var field = new FieldDefinition
-        {
-            Name = "amount",
-            Type = FieldType.Double
-        };
-
-        Assert.Equal("double", TypeMapper.GetFieldCSharpType(field));
-    }
-
-    [Fact]
-    public void GetFieldCSharpType_NullType_ReturnsObject()
-    {
-        var field = new FieldDefinition
-        {
-            Name = "unknown",
-            Type = null
-        };
-
-        Assert.Equal("object", TypeMapper.GetFieldCSharpType(field));
-    }
-
     // ── Metric CLR Types ───────────────────────────────────────────
 
     [Theory]
@@ -122,19 +59,5 @@ public class TypeMapperTests
     public void GetMetricClrType_ReturnsCorrectType(MetricType metricType, string expected)
     {
         Assert.Equal(expected, TypeMapper.GetMetricClrType(metricType));
-    }
-
-    // ── Numeric Type Check ─────────────────────────────────────────
-
-    [Theory]
-    [InlineData(FieldType.Int, true)]
-    [InlineData(FieldType.Long, true)]
-    [InlineData(FieldType.Double, true)]
-    [InlineData(FieldType.String, false)]
-    [InlineData(FieldType.Bool, false)]
-    [InlineData(FieldType.DateTime, false)]
-    public void IsNumericType_ReturnsCorrectResult(FieldType fieldType, bool expected)
-    {
-        Assert.Equal(expected, TypeMapper.IsNumericType(fieldType));
     }
 }

--- a/tests/OtelEvents.Schema.Tests/TypedTransactionTests.cs
+++ b/tests/OtelEvents.Schema.Tests/TypedTransactionTests.cs
@@ -673,7 +673,7 @@ public class TypedTransactionTests
                     EventType = EventType.Start,
                     Fields =
                     [
-                        new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }
+                        new FieldDefinition { Name = "orderId", Required = true }
                     ],
                     Metrics =
                     [
@@ -736,7 +736,7 @@ public class TypedTransactionTests
                 EventType = EventType.Start,
                 Fields =
                 [
-                    new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }
+                    new FieldDefinition { Name = "orderId", Required = true }
                 ]
             },
             new EventDefinition
@@ -749,7 +749,7 @@ public class TypedTransactionTests
                 ParentEvent = "new.order",
                 Fields =
                 [
-                    new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }
+                    new FieldDefinition { Name = "orderId", Required = true }
                 ]
             },
             new EventDefinition
@@ -762,7 +762,7 @@ public class TypedTransactionTests
                 ParentEvent = "new.order",
                 Fields =
                 [
-                    new FieldDefinition { Name = "orderId", Type = FieldType.String, Required = true }
+                    new FieldDefinition { Name = "orderId", Required = true }
                 ]
             }
         ]


### PR DESCRIPTION
All fields are strings. Shorthand list syntax. Metrics use TryParse. Backward compatible. 585 tests. Closes #42