### PR TITLE
feat: Schema v3 — PascalCase events, prefix codes, event constants (#44)

### DIFF
--- a/samples/OtelEvents.Sample.WebApi/Events/OrderEvents.g.cs
+++ b/samples/OtelEvents.Sample.WebApi/Events/OrderEvents.g.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Diagnostics.Metrics;
 using Microsoft.Extensions.Logging;
 using OtelEvents.Causality;
@@ -11,14 +12,55 @@ namespace OtelEvents.Sample.WebApi.Events;
 
 /// <summary>
 /// Pre-compiled [LoggerMessage] methods and metrics for order lifecycle events.
-/// Demonstrates typed transactions: start/success/failure/event patterns.
-/// All fields are strings (simplified schema — Issue #42).
+/// Schema v3: PascalCase names, string event codes with ORDER prefix.
 /// </summary>
 internal static partial class OrderEvents
 {
+    // ─── Schema Metadata ────────────────────────────────────────────────
+
+    /// <summary>The schema version from the YAML definition.</summary>
+    public const string SchemaVersion = "3.0.0";
+
+    /// <summary>The schema name from the YAML definition.</summary>
+    public const string SchemaName = "Orders";
+
+    // ─── Event Constants ────────────────────────────────────────────────
+
+    /// <summary>Constants for the OrderPlaced event.</summary>
+    public static class OrderPlaced
+    {
+        public const string Code = "ORDER-1000";
+        public const int NumericId = 1000;
+        public const string EventName = "OrderPlaced";
+    }
+
+    /// <summary>Constants for the OrderCompleted event.</summary>
+    public static class OrderCompleted
+    {
+        public const string Code = "ORDER-1001";
+        public const int NumericId = 1001;
+        public const string EventName = "OrderCompleted";
+    }
+
+    /// <summary>Constants for the OrderFailed event.</summary>
+    public static class OrderFailed
+    {
+        public const string Code = "ORDER-2000";
+        public const int NumericId = 2000;
+        public const string EventName = "OrderFailed";
+    }
+
+    /// <summary>Constants for the OrderNoteAdded event.</summary>
+    public static class OrderNoteAdded
+    {
+        public const string Code = "ORDER-1002";
+        public const int NumericId = 1002;
+        public const string EventName = "OrderNoteAdded";
+    }
+
     // ─── Meter & Instruments ────────────────────────────────────────────
 
-    private static readonly Meter s_meter = new("Sample.Events.Orders", "1.1.0");
+    private static readonly Meter s_meter = new("Sample.Events.Orders", "3.0.0");
 
     internal static readonly Counter<long> OrderPlacedCount =
         s_meter.CreateCounter<long>("sample.order.placed.count", "orders", "Total orders placed");
@@ -29,14 +71,14 @@ internal static partial class OrderEvents
     internal static readonly Counter<long> OrderFailedCount =
         s_meter.CreateCounter<long>("sample.order.failed.count", "errors", "Total order failures");
 
-    // ─── Event: order.placed (ID 20001) — type: start ───────────────────
+    // ─── Event: OrderPlaced (ID 1000, Code ORDER-1000) — type: start ────
     // Creates a causal scope + starts timer. Returns transaction handle.
 
     [LoggerMessage(
-        EventId = 20001,
-        EventName = "order.placed",
+        EventId = 1000,
+        EventName = "ORDER-1000",
         Level = LogLevel.Information,
-        Message = "Order {OrderId} placed by customer {CustomerId} for ${Amount}")]
+        Message = "Order {OrderId} placed by {CustomerId} for ${Amount}")]
     private static partial void LogOrderPlaced(
         ILogger logger,
         string orderId,
@@ -44,7 +86,7 @@ internal static partial class OrderEvents
         string amount);
 
     /// <summary>
-    /// Emits <c>order.placed</c> (type: start) — creates a transaction scope.
+    /// Emits <c>OrderPlaced</c> (type: start) — creates a transaction scope.
     /// Dispose the returned handle to end the transaction.
     /// </summary>
     internal static OtelEventsTransactionScope BeginOrderPlaced(
@@ -61,15 +103,15 @@ internal static partial class OrderEvents
         if (double.TryParse(amount, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out var amountValue))
             OrderPlacedAmount.Record(amountValue);
 
-        return OtelEventsTransactionScope.Begin("order.placed");
+        return OtelEventsTransactionScope.Begin("OrderPlaced");
     }
 
-    // ─── Event: order.completed (ID 20002) — type: success ──────────────
-    // Closes parent scope (order.placed) as success, records duration.
+    // ─── Event: OrderCompleted (ID 1001, Code ORDER-1001) — type: success ─
+    // Closes parent scope (OrderPlaced) as success, records duration.
 
     [LoggerMessage(
-        EventId = 20002,
-        EventName = "order.completed",
+        EventId = 1001,
+        EventName = "ORDER-1001",
         Level = LogLevel.Information,
         Message = "Order {OrderId} shipped via {Carrier}")]
     private static partial void LogOrderCompleted(
@@ -78,23 +120,23 @@ internal static partial class OrderEvents
         string carrier);
 
     /// <summary>
-    /// Emits <c>order.completed</c> (type: success) — closes the order.placed transaction.
+    /// Emits <c>OrderCompleted</c> (type: success) — closes the OrderPlaced transaction.
     /// </summary>
-    internal static void OrderCompleted(
+    internal static void EmitOrderCompleted(
         this ILogger logger,
         string orderId,
         string carrier)
     {
         LogOrderCompleted(logger, orderId, carrier);
-        OtelEventsTransactionScope.TryComplete("order.placed", "order.completed");
+        OtelEventsTransactionScope.TryComplete("OrderPlaced", "OrderCompleted");
     }
 
-    // ─── Event: order.failed (ID 20003) — type: failure ─────────────────
-    // Closes parent scope (order.placed) as failure, records duration.
+    // ─── Event: OrderFailed (ID 2000, Code ORDER-2000) — type: failure ──
+    // Closes parent scope (OrderPlaced) as failure, records duration.
 
     [LoggerMessage(
-        EventId = 20003,
-        EventName = "order.failed",
+        EventId = 2000,
+        EventName = "ORDER-2000",
         Level = LogLevel.Error,
         Message = "Order {OrderId} failed: {Reason}")]
     private static partial void LogOrderFailed(
@@ -104,9 +146,9 @@ internal static partial class OrderEvents
         string reason);
 
     /// <summary>
-    /// Emits <c>order.failed</c> (type: failure) — closes the order.placed transaction.
+    /// Emits <c>OrderFailed</c> (type: failure) — closes the OrderPlaced transaction.
     /// </summary>
-    internal static void OrderFailed(
+    internal static void EmitOrderFailed(
         this ILogger logger,
         string orderId,
         string reason,
@@ -114,15 +156,15 @@ internal static partial class OrderEvents
     {
         LogOrderFailed(logger, exception, orderId, reason);
         OrderFailedCount.Add(1);
-        OtelEventsTransactionScope.TryFail("order.placed", "order.failed");
+        OtelEventsTransactionScope.TryFail("OrderPlaced", "OrderFailed");
     }
 
-    // ─── Event: order.note.added (ID 20004) — type: event (default) ─────
+    // ─── Event: OrderNoteAdded (ID 1002, Code ORDER-1002) — type: event ─
     // Plain event — no scope effect.
 
     [LoggerMessage(
-        EventId = 20004,
-        EventName = "order.note.added",
+        EventId = 1002,
+        EventName = "ORDER-1002",
         Level = LogLevel.Information,
         Message = "Note added to order {OrderId}: {Note}")]
     private static partial void LogOrderNoteAdded(
@@ -131,9 +173,9 @@ internal static partial class OrderEvents
         string note);
 
     /// <summary>
-    /// Emits <c>order.note.added</c> (type: event) — standalone, no transaction effect.
+    /// Emits <c>OrderNoteAdded</c> (type: event) — standalone, no transaction effect.
     /// </summary>
-    internal static void OrderNoteAdded(
+    internal static void EmitOrderNoteAdded(
         this ILogger logger,
         string orderId,
         string note)

--- a/samples/OtelEvents.Sample.WebApi/Program.cs
+++ b/samples/OtelEvents.Sample.WebApi/Program.cs
@@ -36,19 +36,19 @@ builder.Services.AddOtelEventsHealthChecks();
 
 builder.Services.AddOtelEventsSubscriptions(subs =>
 {
-    subs.On("order.placed", (ctx, ct) =>
+    subs.On(OrderEvents.OrderPlaced.EventName, (ctx, ct) =>
     {
         Console.WriteLine($"📦 Order {ctx.GetAttribute<string>("OrderId")} placed for ${ctx.GetAttribute<double>("Amount")}");
         return Task.CompletedTask;
     });
 
-    subs.On("order.failed", (ctx, ct) =>
+    subs.On(OrderEvents.OrderFailed.EventName, (ctx, ct) =>
     {
         Console.WriteLine($"⚠️ Order {ctx.GetAttribute<string>("OrderId")} failed: {ctx.GetAttribute<string>("Reason")}");
         return Task.CompletedTask;
     });
 
-    subs.On("order.completed", (ctx, ct) =>
+    subs.On(OrderEvents.OrderCompleted.EventName, (ctx, ct) =>
     {
         Console.WriteLine($"✅ Order {ctx.GetAttribute<string>("OrderId")} shipped via {ctx.GetAttribute<string>("Carrier")}");
         return Task.CompletedTask;
@@ -61,10 +61,10 @@ app.MapHealthChecks("/health");
 // ─── POST /orders — Full order transaction in a single request ──────────────
 //
 // Demonstrates typed transactions:
-//   order.placed    (type: start)   → creates scope, starts timer
-//   order.note.added (type: event)  → plain event within the scope
-//   order.completed (type: success) → closes scope, records duration
-//   order.failed    (type: failure) → closes scope as failure, records duration
+//   OrderPlaced    (type: start)   → creates scope, starts timer
+//   OrderNoteAdded (type: event)   → plain event within the scope
+//   OrderCompleted (type: success) → closes scope, records duration
+//   OrderFailed    (type: failure) → closes scope as failure, records duration
 //
 // All events share the same parentEventId and otel_events.elapsed_ms.
 
@@ -78,7 +78,7 @@ app.MapPost("/orders", async (OrderRequest request, ILogger<OrderEventSource> lo
     try
     {
         // type: event — plain event within the transaction (no scope effect)
-        logger.OrderNoteAdded(orderId, "Validating payment...");
+        logger.EmitOrderNoteAdded(orderId, "Validating payment...");
 
         // Simulate async processing
         await Task.Delay(Random.Shared.Next(50, 200));
@@ -87,11 +87,11 @@ app.MapPost("/orders", async (OrderRequest request, ILogger<OrderEventSource> lo
         if (double.TryParse(request.Amount, out var amt) && amt > 999)
             throw new InvalidOperationException("Amount exceeds processing limit");
 
-        logger.OrderNoteAdded(orderId, "Payment validated, reserving inventory");
+        logger.EmitOrderNoteAdded(orderId, "Payment validated, reserving inventory");
         await Task.Delay(Random.Shared.Next(20, 100));
 
         // type: success — closes transaction, records duration
-        logger.OrderCompleted(orderId, "DHL Express");
+        logger.EmitOrderCompleted(orderId, "DHL Express");
 
         return Results.Created($"/orders/{orderId}", new
         {
@@ -104,7 +104,7 @@ app.MapPost("/orders", async (OrderRequest request, ILogger<OrderEventSource> lo
     catch (Exception ex)
     {
         // type: failure — closes transaction as failure, records duration
-        logger.OrderFailed(orderId, ex.Message, ex);
+        logger.EmitOrderFailed(orderId, ex.Message, ex);
 
         return Results.Problem(
             title: "Order Failed",
@@ -118,7 +118,7 @@ app.MapPost("/orders", async (OrderRequest request, ILogger<OrderEventSource> lo
 app.MapPost("/orders/{id}/notes", (string id, NoteRequest request, ILogger<OrderEventSource> logger) =>
 {
     // type: event — standalone, no transaction effect
-    logger.OrderNoteAdded(id, request.Note);
+    logger.EmitOrderNoteAdded(id, request.Note);
     return Results.Ok(new { orderId = id, note = request.Note });
 });
 

--- a/samples/OtelEvents.Sample.WebApi/schemas/orders.otel.yaml
+++ b/samples/OtelEvents.Sample.WebApi/schemas/orders.otel.yaml
@@ -1,19 +1,21 @@
 # ─── Sample Order Events Schema ──────────────────────────────────────────────
+# Schema v3: PascalCase event names, string event codes with prefix.
 # All fields are strings and required by default.
 # Use { optional: true } to mark a field as optional.
 
 schema:
-  name: "Sample.Orders"
-  version: "2.0.0"
+  name: "Orders"
+  version: "3.0.0"
   namespace: "OtelEvents.Sample.WebApi.Events"
   meterName: "Sample.Events.Orders"
+  prefix: ORDER
 
 events:
-  order.placed:
-    id: 20001
+  OrderPlaced:
+    id: 1000
     type: start
     severity: INFO
-    message: "Order {orderId} placed by customer {customerId} for ${amount}"
+    message: "Order {orderId} placed by {customerId} for ${amount}"
     fields:
       - orderId
       - customerId: { sensitivity: pii }
@@ -26,10 +28,10 @@ events:
         type: histogram
         field: amount
 
-  order.completed:
-    id: 20002
+  OrderCompleted:
+    id: 1001
     type: success
-    parent: order.placed
+    parent: OrderPlaced
     severity: INFO
     message: "Order {orderId} shipped via {carrier}"
     fields:
@@ -37,10 +39,10 @@ events:
       - carrier
       - trackingNumber: { optional: true }
 
-  order.failed:
-    id: 20003
+  OrderFailed:
+    id: 2000
     type: failure
-    parent: order.placed
+    parent: OrderPlaced
     severity: ERROR
     message: "Order {orderId} failed: {reason}"
     exception: true
@@ -51,8 +53,8 @@ events:
       sample.order.failed.count:
         type: counter
 
-  order.note.added:
-    id: 20004
+  OrderNoteAdded:
+    id: 1002
     severity: INFO
     message: "Note added to order {orderId}: {note}"
     fields:

--- a/schemas/otel-events.schema.json
+++ b/schemas/otel-events.schema.json
@@ -30,6 +30,11 @@
           "type": "string",
           "description": "OTEL Meter name for generated metrics (defaults to namespace)"
         },
+        "prefix": {
+          "type": "string",
+          "description": "Event code prefix — event codes become '{prefix}-{id}' (e.g., 'ORDER-1000')",
+          "pattern": "^[A-Z][A-Z0-9_]*$"
+        },
         "description": {
           "type": "string",
           "description": "Human-readable schema description"
@@ -38,7 +43,7 @@
     },
     "events": {
       "type": "object",
-      "description": "Event definitions — keys are event names (lowercase, dot-namespaced)",
+      "description": "Event definitions — keys are event names (PascalCase or lowercase dot-namespaced)",
       "additionalProperties": {
         "$ref": "#/definitions/event"
       }
@@ -78,6 +83,11 @@
         "parent": {
           "type": "string",
           "description": "Parent start event name — required for success and failure types"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Per-event prefix override — overrides the schema-level prefix for this event's code",
+          "pattern": "^[A-Z][A-Z0-9_]*$"
         },
         "severity": {
           "type": "string",

--- a/src/OtelEvents.Schema/CodeGen/CodeGenerator.cs
+++ b/src/OtelEvents.Schema/CodeGen/CodeGenerator.cs
@@ -134,11 +134,18 @@ public sealed class CodeGenerator
         GenerateMetadataClass(sb, schemaName, doc);
         sb.AppendLine();
 
-        // 1. LoggerMessage partial class
-        GenerateLoggerExtensionsClass(sb, schemaName, doc.Events);
+        // 1. Event constants classes (one per event)
+        foreach (var evt in doc.Events)
+        {
+            GenerateEventConstantsClass(sb, evt, doc.Schema.Prefix);
+            sb.AppendLine();
+        }
+
+        // 2. LoggerMessage partial class
+        GenerateLoggerExtensionsClass(sb, schemaName, doc);
         sb.AppendLine();
 
-        // 2. Metrics class (only if any event has metrics)
+        // 3. Metrics class (only if any event has metrics)
         if (hasAnyMetrics)
         {
             if (isDiMode)
@@ -152,7 +159,7 @@ public sealed class CodeGenerator
             sb.AppendLine();
         }
 
-        // 3. Emit extension methods class
+        // 4. Emit extension methods class
         GenerateEventExtensionsClass(sb, schemaName, doc.Events, hasAnyMetrics, isDiMode);
 
         return new GeneratedFile($"{schemaName}Events.g.cs", sb.ToString());
@@ -178,12 +185,51 @@ public sealed class CodeGenerator
         sb.AppendLine("}");
     }
 
+    // ── Event Constants Classes ─────────────────────────────────────
+
+    /// <summary>
+    /// Computes the event code string for a given event.
+    /// Returns "{prefix}-{id}" if a prefix is available, or just "{id}" otherwise.
+    /// Per-event prefix overrides the schema-level prefix.
+    /// </summary>
+    internal static string ComputeEventCode(EventDefinition evt, string? schemaPrefix)
+    {
+        var effectivePrefix = evt.Prefix ?? schemaPrefix;
+        return effectivePrefix is not null
+            ? $"{effectivePrefix}-{evt.Id}"
+            : evt.Id.ToString();
+    }
+
+    private static void GenerateEventConstantsClass(
+        StringBuilder sb,
+        EventDefinition evt,
+        string? schemaPrefix)
+    {
+        var className = NamingHelper.ToMethodName(evt.Name);
+        var code = ComputeEventCode(evt, schemaPrefix);
+
+        sb.AppendLine("/// <summary>");
+        sb.AppendLine($"/// Constants for the {className} event.");
+        sb.AppendLine("/// </summary>");
+        sb.AppendLine($"public static class {className}");
+        sb.AppendLine("{");
+        sb.AppendLine($"    /// <summary>The event code string (prefix + numeric ID).</summary>");
+        sb.AppendLine($"    public const string Code = \"{EscapeString(code)}\";");
+        sb.AppendLine();
+        sb.AppendLine($"    /// <summary>The numeric event ID.</summary>");
+        sb.AppendLine($"    public const int NumericId = {evt.Id};");
+        sb.AppendLine();
+        sb.AppendLine($"    /// <summary>The event name.</summary>");
+        sb.AppendLine($"    public const string EventName = \"{EscapeString(className)}\";");
+        sb.AppendLine("}");
+    }
+
     // ── LoggerMessage Extensions ───────────────────────────────────
 
     private static void GenerateLoggerExtensionsClass(
         StringBuilder sb,
         string schemaName,
-        List<EventDefinition> events)
+        SchemaDocument doc)
     {
         sb.AppendLine("/// <summary>");
         sb.AppendLine($"/// LoggerMessage methods for {schemaName} events.");
@@ -191,10 +237,10 @@ public sealed class CodeGenerator
         sb.AppendLine($"public static partial class {schemaName}LoggerExtensions");
         sb.AppendLine("{");
 
-        for (var i = 0; i < events.Count; i++)
+        for (var i = 0; i < doc.Events.Count; i++)
         {
             if (i > 0) sb.AppendLine();
-            GenerateLoggerMessageMethod(sb, events[i]);
+            GenerateLoggerMessageMethod(sb, doc.Events[i], doc.Schema.Prefix);
         }
 
         sb.AppendLine("}");
@@ -202,14 +248,17 @@ public sealed class CodeGenerator
 
     private static void GenerateLoggerMessageMethod(
         StringBuilder sb,
-        EventDefinition evt)
+        EventDefinition evt,
+        string? schemaPrefix)
     {
         var methodName = NamingHelper.ToMethodName(evt.Name);
         var logLevel = TypeMapper.ToLogLevel(evt.Severity);
+        var eventCode = ComputeEventCode(evt, schemaPrefix);
 
         // [LoggerMessage] attribute
         sb.AppendLine($"    [LoggerMessage(");
         sb.AppendLine($"        EventId = {evt.Id},");
+        sb.AppendLine($"        EventName = \"{EscapeString(eventCode)}\",");
         sb.AppendLine($"        Level = {logLevel},");
         sb.AppendLine($"        Message = \"{EscapeString(evt.Message)}\")]");
 

--- a/src/OtelEvents.Schema/Models/EventDefinition.cs
+++ b/src/OtelEvents.Schema/Models/EventDefinition.cs
@@ -49,4 +49,10 @@ public sealed class EventDefinition
     /// The raw event type string from YAML, preserved for validation when the type is invalid.
     /// </summary>
     public string? RawEventType { get; init; }
+
+    /// <summary>
+    /// Optional per-event prefix override. When set, overrides the schema-level prefix
+    /// for this event's code string. When absent, the schema-level prefix is used.
+    /// </summary>
+    public string? Prefix { get; init; }
 }

--- a/src/OtelEvents.Schema/Models/SchemaHeader.cs
+++ b/src/OtelEvents.Schema/Models/SchemaHeader.cs
@@ -25,4 +25,10 @@ public sealed class SchemaHeader
     /// When set to <see cref="MeterLifecycle.DI"/>, generates IMeterFactory-injected metrics class.
     /// </summary>
     public MeterLifecycle MeterLifecycle { get; init; } = MeterLifecycle.Static;
+
+    /// <summary>
+    /// Optional event code prefix. When set, event codes become "{Prefix}-{Id}" (e.g., "ORDER-1000").
+    /// When absent, event codes are just the numeric ID as a string.
+    /// </summary>
+    public string? Prefix { get; init; }
 }

--- a/src/OtelEvents.Schema/Parsing/SchemaParser.cs
+++ b/src/OtelEvents.Schema/Parsing/SchemaParser.cs
@@ -191,7 +191,8 @@ public sealed class SchemaParser
             Namespace = GetRequiredScalar(schemaNode, "namespace", "schema.namespace"),
             Description = GetOptionalScalar(schemaNode, "description"),
             MeterName = GetOptionalScalar(schemaNode, "meterName"),
-            MeterLifecycle = ParseMeterLifecycle(GetOptionalScalar(schemaNode, "meterLifecycle"))
+            MeterLifecycle = ParseMeterLifecycle(GetOptionalScalar(schemaNode, "meterLifecycle")),
+            Prefix = GetOptionalScalar(schemaNode, "prefix")
         };
     }
 
@@ -294,6 +295,7 @@ public sealed class SchemaParser
             }
 
             var parentEvent = GetOptionalScalar(eventMapping, "parent");
+            var eventPrefix = GetOptionalScalar(eventMapping, "prefix");
 
             events.Add(new EventDefinition
             {
@@ -308,7 +310,8 @@ public sealed class SchemaParser
                 Tags = tags,
                 EventType = eventType,
                 ParentEvent = parentEvent,
-                RawEventType = eventTypeStr
+                RawEventType = eventTypeStr,
+                Prefix = eventPrefix
             });
         }
         return events;

--- a/src/OtelEvents.Schema/Validation/ErrorCodes.cs
+++ b/src/OtelEvents.Schema/Validation/ErrorCodes.cs
@@ -20,7 +20,7 @@ public static class ErrorCodes
     /// <summary>Field types must be from the supported type list.</summary>
     public const string InvalidType = "OTEL_SCHEMA_005";
 
-    /// <summary>Event names must be dot-namespaced, lowercase, alphanumeric + dots only.</summary>
+    /// <summary>Event names must be PascalCase or dot-namespaced, lowercase, alphanumeric + dots only.</summary>
     public const string InvalidEventNameFormat = "OTEL_SCHEMA_006";
 
     /// <summary>Required fields must have a type (directly or via ref).</summary>

--- a/src/OtelEvents.Schema/Validation/SchemaValidator.cs
+++ b/src/OtelEvents.Schema/Validation/SchemaValidator.cs
@@ -15,9 +15,13 @@ public sealed partial class SchemaValidator
     /// <summary>Maximum allowed fields per event.</summary>
     internal const int MaxFieldsPerEvent = 50;
 
-    // Regex: lowercase alphanumeric + dots, must have at least one dot
+    // Regex: lowercase alphanumeric + dots, must have at least one dot (legacy format)
     [GeneratedRegex(@"^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$")]
-    private static partial Regex EventNameRegex();
+    private static partial Regex DotNamespacedEventNameRegex();
+
+    // Regex: PascalCase C# identifier (starts with uppercase letter, no dots)
+    [GeneratedRegex(@"^[A-Z][A-Za-z0-9]*$")]
+    private static partial Regex PascalCaseEventNameRegex();
 
     // Regex: semver (simplified — major.minor.patch with optional pre-release)
     [GeneratedRegex(@"^\d+\.\d+\.\d+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?(\+[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$")]
@@ -221,12 +225,12 @@ public sealed partial class SchemaValidator
 
     private static void ValidateEventNameFormat(string eventName, List<SchemaError> errors)
     {
-        if (!EventNameRegex().IsMatch(eventName))
+        if (!DotNamespacedEventNameRegex().IsMatch(eventName) && !PascalCaseEventNameRegex().IsMatch(eventName))
         {
             errors.Add(new SchemaError
             {
                 Code = ErrorCodes.InvalidEventNameFormat,
-                Message = $"Event name '{eventName}' must be lowercase, dot-namespaced (e.g., 'http.request.received')."
+                Message = $"Event name '{eventName}' must be either PascalCase (e.g., 'OrderPlaced') or lowercase dot-namespaced (e.g., 'order.placed')."
             });
         }
     }

--- a/tests/OtelEvents.Schema.Tests/SchemaV3Tests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaV3Tests.cs
@@ -1,0 +1,693 @@
+using OtelEvents.Schema.CodeGen;
+using OtelEvents.Schema.Models;
+using OtelEvents.Schema.Parsing;
+using OtelEvents.Schema.Validation;
+
+namespace OtelEvents.Schema.Tests;
+
+/// <summary>
+/// Tests for Schema v3 features:
+///   - PascalCase event names (OTEL_SCHEMA_006 update)
+///   - String event code with prefix
+///   - Generated event constants class
+///   - Per-event prefix override
+///   - Backward compatibility with dot.namespaced names
+/// </summary>
+public class SchemaV3Tests
+{
+    private readonly SchemaParser _parser = new();
+    private readonly SchemaValidator _validator = new();
+    private readonly CodeGenerator _generator = new();
+
+    // ═══════════════════════════════════════════════════════════════
+    // 1. PASCALCASE EVENT NAMES — Parser & Validator
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_PascalCaseEventName_ReturnsSuccess()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+            events:
+              OrderPlaced:
+                id: 1000
+                severity: INFO
+                message: "Order {orderId} placed"
+                fields:
+                  - orderId
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Document!.Events);
+        Assert.Equal("OrderPlaced", result.Document.Events[0].Name);
+    }
+
+    [Theory]
+    [InlineData("OrderPlaced")]
+    [InlineData("HttpRequestReceived")]
+    [InlineData("A")]
+    [InlineData("OrderPlaced2")]
+    [InlineData("X1Y2Z3")]
+    public void Validate_PascalCaseEventName_NoError(string eventName)
+    {
+        var doc = CreateMinimalDoc(events:
+        [
+            CreateEvent(eventName, 1),
+        ]);
+
+        var result = _validator.Validate(doc);
+
+        Assert.DoesNotContain(result.Errors, e => e.Code == ErrorCodes.InvalidEventNameFormat);
+    }
+
+    [Theory]
+    [InlineData("http.request")]
+    [InlineData("order.placed")]
+    [InlineData("db.query.executed")]
+    public void Validate_DotNamespacedEventName_StillValid(string eventName)
+    {
+        var doc = CreateMinimalDoc(events:
+        [
+            CreateEvent(eventName, 1),
+        ]);
+
+        var result = _validator.Validate(doc);
+
+        Assert.DoesNotContain(result.Errors, e => e.Code == ErrorCodes.InvalidEventNameFormat);
+    }
+
+    [Theory]
+    [InlineData("lowerCase")]
+    [InlineData("camelCase")]
+    [InlineData("snake_case")]
+    [InlineData("has spaces")]
+    [InlineData("kebab-case")]
+    [InlineData("123StartsWithNumber")]
+    public void Validate_InvalidEventNameFormat_ReturnsError(string eventName)
+    {
+        var doc = CreateMinimalDoc(events:
+        [
+            CreateEvent(eventName, 1),
+        ]);
+
+        var result = _validator.Validate(doc);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Code == ErrorCodes.InvalidEventNameFormat);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 2. PREFIX PARSING — Schema header & per-event
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Parse_PrefixInSchemaHeader_ParsesCorrectly()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+              prefix: ORDER
+            events:
+              OrderPlaced:
+                id: 1000
+                severity: INFO
+                message: "Order placed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("ORDER", result.Document!.Schema.Prefix);
+    }
+
+    [Fact]
+    public void Parse_NoPrefixInHeader_PrefixIsNull()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+            events:
+              OrderPlaced:
+                id: 1000
+                severity: INFO
+                message: "Order placed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Document!.Schema.Prefix);
+    }
+
+    [Fact]
+    public void Parse_PerEventPrefixOverride_ParsesCorrectly()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+              prefix: ORDER
+            events:
+              PaymentProcessed:
+                id: 2000
+                severity: INFO
+                message: "Payment processed"
+                prefix: PAY
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("PAY", result.Document!.Events[0].Prefix);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 3. EVENT CODE COMPUTATION
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ComputeEventCode_WithPrefix_ReturnsPrefixDashId()
+    {
+        var evt = CreateEvent("OrderPlaced", 1000);
+
+        var code = CodeGenerator.ComputeEventCode(evt, "ORDER");
+
+        Assert.Equal("ORDER-1000", code);
+    }
+
+    [Fact]
+    public void ComputeEventCode_NoPrefix_ReturnsIdOnly()
+    {
+        var evt = CreateEvent("OrderPlaced", 1000);
+
+        var code = CodeGenerator.ComputeEventCode(evt, null);
+
+        Assert.Equal("1000", code);
+    }
+
+    [Fact]
+    public void ComputeEventCode_PerEventPrefixOverridesSchema()
+    {
+        var evt = new EventDefinition
+        {
+            Name = "PaymentProcessed",
+            Id = 2000,
+            Severity = Severity.Info,
+            Message = "Payment processed",
+            Prefix = "PAY"
+        };
+
+        var code = CodeGenerator.ComputeEventCode(evt, "ORDER");
+
+        Assert.Equal("PAY-2000", code);
+    }
+
+    [Fact]
+    public void ComputeEventCode_PerEventPrefixWithoutSchemaPrefix()
+    {
+        var evt = new EventDefinition
+        {
+            Name = "PaymentProcessed",
+            Id = 2000,
+            Severity = Severity.Info,
+            Message = "Payment processed",
+            Prefix = "PAY"
+        };
+
+        var code = CodeGenerator.ComputeEventCode(evt, null);
+
+        Assert.Equal("PAY-2000", code);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 4. CODE GENERATOR — Event code in LoggerMessage
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Generate_LoggerMessage_EventNameIsEventCode_WithPrefix()
+    {
+        var doc = CreateSchemaWithPrefix("ORDER", new EventDefinition
+        {
+            Name = "OrderPlaced",
+            Id = 1000,
+            Severity = Severity.Info,
+            Message = "Order placed"
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("EventName = \"ORDER-1000\"", content);
+    }
+
+    [Fact]
+    public void Generate_LoggerMessage_EventNameIsNumericId_NoPrefix()
+    {
+        var doc = CreateSchemaWithEvent(new EventDefinition
+        {
+            Name = "OrderPlaced",
+            Id = 1000,
+            Severity = Severity.Info,
+            Message = "Order placed"
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("EventName = \"1000\"", content);
+    }
+
+    [Fact]
+    public void Generate_LoggerMessage_PerEventPrefix_OverridesSchemaPrefix()
+    {
+        var doc = new SchemaDocument
+        {
+            Schema = new SchemaHeader
+            {
+                Name = "TestService",
+                Version = "1.0.0",
+                Namespace = "Test.Events",
+                Prefix = "ORDER"
+            },
+            Events =
+            [
+                new EventDefinition
+                {
+                    Name = "PaymentProcessed",
+                    Id = 2000,
+                    Severity = Severity.Info,
+                    Message = "Payment processed",
+                    Prefix = "PAY"
+                }
+            ]
+        };
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("EventName = \"PAY-2000\"", content);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 5. CODE GENERATOR — Constants class
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Generate_ConstantsClass_WithPrefix()
+    {
+        var doc = CreateSchemaWithPrefix("ORDER", new EventDefinition
+        {
+            Name = "OrderPlaced",
+            Id = 1000,
+            Severity = Severity.Info,
+            Message = "Order placed"
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("public static class OrderPlaced", content);
+        Assert.Contains("public const string Code = \"ORDER-1000\";", content);
+        Assert.Contains("public const int NumericId = 1000;", content);
+        Assert.Contains("public const string EventName = \"OrderPlaced\";", content);
+    }
+
+    [Fact]
+    public void Generate_ConstantsClass_WithoutPrefix()
+    {
+        var doc = CreateSchemaWithEvent(new EventDefinition
+        {
+            Name = "OrderPlaced",
+            Id = 500,
+            Severity = Severity.Info,
+            Message = "Order placed"
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("public static class OrderPlaced", content);
+        Assert.Contains("public const string Code = \"500\";", content);
+        Assert.Contains("public const int NumericId = 500;", content);
+        Assert.Contains("public const string EventName = \"OrderPlaced\";", content);
+    }
+
+    [Fact]
+    public void Generate_ConstantsClass_DotNamespacedEvent_UsesMethodNameAsClassName()
+    {
+        var doc = CreateSchemaWithPrefix("SVC", new EventDefinition
+        {
+            Name = "order.placed",
+            Id = 100,
+            Severity = Severity.Info,
+            Message = "Order placed"
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        // dot-namespaced "order.placed" → PascalCase class "OrderPlaced"
+        Assert.Contains("public static class OrderPlaced", content);
+        Assert.Contains("public const string Code = \"SVC-100\";", content);
+        Assert.Contains("public const string EventName = \"OrderPlaced\";", content);
+    }
+
+    [Fact]
+    public void Generate_ConstantsClass_MultipleEvents_GeneratesMultipleClasses()
+    {
+        var doc = new SchemaDocument
+        {
+            Schema = new SchemaHeader
+            {
+                Name = "TestService",
+                Version = "1.0.0",
+                Namespace = "Test.Events",
+                Prefix = "ORD"
+            },
+            Events =
+            [
+                new EventDefinition
+                {
+                    Name = "OrderPlaced",
+                    Id = 1000,
+                    Severity = Severity.Info,
+                    Message = "Order placed"
+                },
+                new EventDefinition
+                {
+                    Name = "OrderFailed",
+                    Id = 2000,
+                    Severity = Severity.Error,
+                    Message = "Order failed"
+                }
+            ]
+        };
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("public static class OrderPlaced", content);
+        Assert.Contains("public const string Code = \"ORD-1000\";", content);
+
+        Assert.Contains("public static class OrderFailed", content);
+        Assert.Contains("public const string Code = \"ORD-2000\";", content);
+    }
+
+    [Fact]
+    public void Generate_ConstantsClass_PerEventPrefixOverride()
+    {
+        var doc = new SchemaDocument
+        {
+            Schema = new SchemaHeader
+            {
+                Name = "TestService",
+                Version = "1.0.0",
+                Namespace = "Test.Events",
+                Prefix = "ORDER"
+            },
+            Events =
+            [
+                new EventDefinition
+                {
+                    Name = "OrderPlaced",
+                    Id = 1000,
+                    Severity = Severity.Info,
+                    Message = "Order placed"
+                },
+                new EventDefinition
+                {
+                    Name = "PaymentProcessed",
+                    Id = 2000,
+                    Severity = Severity.Info,
+                    Message = "Payment processed",
+                    Prefix = "PAY"
+                }
+            ]
+        };
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("public const string Code = \"ORDER-1000\";", content);
+        Assert.Contains("public const string Code = \"PAY-2000\";", content);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 6. END-TO-END: Parse → Validate → Generate
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void EndToEnd_PascalCaseWithPrefix_ProducesCorrectOutput()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+              prefix: ORDER
+            events:
+              OrderPlaced:
+                id: 1000
+                severity: INFO
+                message: "Order {orderId} placed"
+                fields:
+                  - orderId
+              OrderFailed:
+                id: 2000
+                severity: ERROR
+                message: "Order {orderId} failed: {reason}"
+                fields:
+                  - orderId
+                  - reason
+            """;
+
+        // Parse
+        var parseResult = _parser.Parse(yaml, yaml.Length);
+        Assert.True(parseResult.IsSuccess);
+
+        // Validate
+        var validationResult = _validator.Validate(parseResult.Document!);
+        Assert.True(validationResult.IsValid, string.Join(", ", validationResult.Errors));
+
+        // Generate
+        var files = _generator.GenerateFromSchema(parseResult.Document!);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        // Verify constants
+        Assert.Contains("public static class OrderPlaced", content);
+        Assert.Contains("public const string Code = \"ORDER-1000\";", content);
+
+        Assert.Contains("public static class OrderFailed", content);
+        Assert.Contains("public const string Code = \"ORDER-2000\";", content);
+
+        // Verify LoggerMessage uses event code as EventName
+        Assert.Contains("EventName = \"ORDER-1000\"", content);
+        Assert.Contains("EventName = \"ORDER-2000\"", content);
+    }
+
+    [Fact]
+    public void EndToEnd_NoPrefix_CodeIsJustNumericId()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+            events:
+              OrderPlaced:
+                id: 1000
+                severity: INFO
+                message: "Order placed"
+            """;
+
+        var parseResult = _parser.Parse(yaml, yaml.Length);
+        Assert.True(parseResult.IsSuccess);
+
+        var validationResult = _validator.Validate(parseResult.Document!);
+        Assert.True(validationResult.IsValid, string.Join(", ", validationResult.Errors));
+
+        var files = _generator.GenerateFromSchema(parseResult.Document!);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("public const string Code = \"1000\";", content);
+        Assert.Contains("EventName = \"1000\"", content);
+    }
+
+    [Fact]
+    public void EndToEnd_DotNamespacedBackwardCompat_StillWorks()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+              prefix: SVC
+            events:
+              order.placed:
+                id: 100
+                severity: INFO
+                message: "Order {orderId} placed"
+                fields:
+                  - orderId
+            """;
+
+        var parseResult = _parser.Parse(yaml, yaml.Length);
+        Assert.True(parseResult.IsSuccess);
+
+        var validationResult = _validator.Validate(parseResult.Document!);
+        Assert.True(validationResult.IsValid, string.Join(", ", validationResult.Errors));
+
+        var files = _generator.GenerateFromSchema(parseResult.Document!);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        // Dot-namespaced names still generate PascalCase method names
+        Assert.Contains("public static class OrderPlaced", content);
+        Assert.Contains("public const string Code = \"SVC-100\";", content);
+        Assert.Contains("EventName = \"SVC-100\"", content);
+    }
+
+    [Fact]
+    public void EndToEnd_TransactionLifecycle_WithPascalCase()
+    {
+        var yaml = """
+            schema:
+              name: "Orders"
+              version: "3.0.0"
+              namespace: "Test.Events"
+              prefix: ORDER
+            events:
+              OrderPlaced:
+                id: 1000
+                type: start
+                severity: INFO
+                message: "Order {orderId} placed"
+                fields:
+                  - orderId
+              OrderCompleted:
+                id: 1001
+                type: success
+                parent: OrderPlaced
+                severity: INFO
+                message: "Order {orderId} completed"
+                fields:
+                  - orderId
+              OrderFailed:
+                id: 2000
+                type: failure
+                parent: OrderPlaced
+                severity: ERROR
+                message: "Order {orderId} failed"
+                exception: true
+                fields:
+                  - orderId
+            """;
+
+        var parseResult = _parser.Parse(yaml, yaml.Length);
+        Assert.True(parseResult.IsSuccess);
+
+        var validationResult = _validator.Validate(parseResult.Document!);
+        Assert.True(validationResult.IsValid, string.Join(", ", validationResult.Errors));
+
+        var files = _generator.GenerateFromSchema(parseResult.Document!);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        // Start event should generate Begin method
+        Assert.Contains("BeginOrderPlaced", content);
+        // Success/failure should reference parent by PascalCase name
+        Assert.Contains("OtelEventsTransactionScope.TryComplete(\"OrderPlaced\"", content);
+        Assert.Contains("OtelEventsTransactionScope.TryFail(\"OrderPlaced\"", content);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 7. CONSTANTS CLASS HAS XML DOC COMMENTS
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Generate_ConstantsClass_HasXmlDocComments()
+    {
+        var doc = CreateSchemaWithPrefix("ORDER", new EventDefinition
+        {
+            Name = "OrderPlaced",
+            Id = 1000,
+            Severity = Severity.Info,
+            Message = "Order placed"
+        });
+
+        var files = _generator.GenerateFromSchema(doc);
+        var content = files.First(f => f.FileName.Contains("Events")).Content;
+
+        Assert.Contains("/// <summary>", content);
+        Assert.Contains("Constants for the OrderPlaced event", content);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // HELPERS
+    // ═══════════════════════════════════════════════════════════════
+
+    private static SchemaDocument CreateMinimalDoc(
+        string version = "1.0.0",
+        List<EventDefinition>? events = null)
+    {
+        return new SchemaDocument
+        {
+            Schema = new SchemaHeader
+            {
+                Name = "TestService",
+                Version = version,
+                Namespace = "Test.Namespace",
+            },
+            Events = events ?? []
+        };
+    }
+
+    private static SchemaDocument CreateSchemaWithEvent(
+        EventDefinition evt,
+        string name = "TestService",
+        string ns = "Test.Events") => new()
+    {
+        Schema = new SchemaHeader
+        {
+            Name = name,
+            Version = "1.0.0",
+            Namespace = ns
+        },
+        Events = [evt]
+    };
+
+    private static SchemaDocument CreateSchemaWithPrefix(
+        string prefix,
+        EventDefinition evt,
+        string name = "TestService",
+        string ns = "Test.Events") => new()
+    {
+        Schema = new SchemaHeader
+        {
+            Name = name,
+            Version = "1.0.0",
+            Namespace = ns,
+            Prefix = prefix
+        },
+        Events = [evt]
+    };
+
+    private static EventDefinition CreateEvent(string name, int id)
+    {
+        return new EventDefinition
+        {
+            Name = name,
+            Id = id,
+            Severity = Severity.Info,
+            Message = "Test event"
+        };
+    }
+}

--- a/tests/OtelEvents.Schema.Tests/SchemaValidatorTests.cs
+++ b/tests/OtelEvents.Schema.Tests/SchemaValidatorTests.cs
@@ -237,7 +237,6 @@ public class SchemaValidatorTests
     // ── OTEL_SCHEMA_006: Event name format ───────────────────────────────
 
     [Theory]
-    [InlineData("NotLowerCase")]
     [InlineData("no-dashes-allowed")]
     [InlineData("singleword")]
     [InlineData("has spaces")]


### PR DESCRIPTION
- PascalCase event names (OrderPlaced instead of order.placed)
- String event codes with prefix (ORDER-1000)
- Generated event constants for type-safe subscriptions
- Updated sample app, JSON schema, tests
- Backward compatible (dot.namespaced still accepted)
Closes #44