### PR TITLE
feat: add OtelEvents.HttpClient outbound tracking package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />

--- a/OtelEvents.slnx
+++ b/OtelEvents.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/OtelEvents.Cli/OtelEvents.Cli.csproj" />
     <Project Path="src/OtelEvents.Exporter.Json/OtelEvents.Exporter.Json.csproj" />
     <Project Path="src/OtelEvents.Grpc/OtelEvents.Grpc.csproj" />
+    <Project Path="src/OtelEvents.HttpClient/OtelEvents.HttpClient.csproj" />
 
     <Project Path="src/OtelEvents.Schema/OtelEvents.Schema.csproj" />
     <Project Path="src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj" />
@@ -22,6 +23,7 @@
     <Project Path="tests/OtelEvents.Cli.Tests/OtelEvents.Cli.Tests.csproj" />
     <Project Path="tests/OtelEvents.Exporter.Json.Tests/OtelEvents.Exporter.Json.Tests.csproj" />
     <Project Path="tests/OtelEvents.Grpc.Tests/OtelEvents.Grpc.Tests.csproj" />
+    <Project Path="tests/OtelEvents.HttpClient.Tests/OtelEvents.HttpClient.Tests.csproj" />
 
     <Project Path="tests/OtelEvents.Schema.Tests/OtelEvents.Schema.Tests.csproj" />
     <Project Path="tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj" />

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ dotnet add package OtelEvents.Causality        # Causal event linking (eventId/p
 
 # Integration packs — zero-code instrumentation (pick what you use)
 dotnet add package OtelEvents.AspNetCore       # HTTP request/auth/throttle events
+dotnet add package OtelEvents.HttpClient       # Outbound HTTP call events
 dotnet add package OtelEvents.Grpc             # gRPC call/auth/throttle events
 dotnet add package OtelEvents.Azure.CosmosDb   # CosmosDB query/auth/throttle events
 dotnet add package OtelEvents.Azure.Storage    # Blob/Queue operation events
@@ -55,6 +56,7 @@ These packages auto-emit structured events by hooking into framework pipelines. 
 | Package | Events emitted | What it instruments |
 |---------|---------------|-------------------|
 | **OtelEvents.AspNetCore** | `http.request.received/completed/failed` + `http.connection.failed` + `http.auth.failed` + `http.throttled` | ASP.NET Core middleware — every HTTP request |
+| **OtelEvents.HttpClient** | `http.outbound.started/completed/failed` | Outbound HTTP calls via `DelegatingHandler` — every `IHttpClientFactory` call |
 | **OtelEvents.Grpc** | `grpc.call.started/completed/failed` + connection/auth/throttle events | gRPC server + client interceptors |
 | **OtelEvents.Azure.CosmosDb** | `cosmosdb.query.executed/failed` + `cosmosdb.point.read/write` + connection/auth/throttle events | Azure CosmosDB SDK via DiagnosticListener |
 | **OtelEvents.Azure.Storage** | `storage.blob.uploaded/downloaded/deleted` + `storage.queue.sent/received` + connection/auth/throttle events | Azure Storage SDK via HttpPipelinePolicy |
@@ -168,6 +170,7 @@ otel-events-dotnet/
 │   ├── OtelEvents.Testing/             # Test utilities
 │   ├── OtelEvents.Subscriptions/       # In-process event bus
 │   ├── OtelEvents.AspNetCore/          # ASP.NET Core integration pack
+│   ├── OtelEvents.HttpClient/          # Outbound HTTP client integration pack
 │   ├── OtelEvents.Grpc/                # gRPC integration pack
 │   ├── OtelEvents.Azure.CosmosDb/      # Azure CosmosDB integration pack
 │   ├── OtelEvents.Azure.Storage/       # Azure Storage integration pack

--- a/docs/user-guide/06-integration-packs.md
+++ b/docs/user-guide/06-integration-packs.md
@@ -11,6 +11,7 @@ Integration packs are pre-built packages that automatically emit structured even
 | Package | Technology | Events | Registration |
 |---------|-----------|--------|--------------|
 | `OtelEvents.AspNetCore` | ASP.NET Core HTTP | `http.request.received`, `http.request.completed`, `http.request.failed` | `AddOtelEventsAspNetCore()` |
+| `OtelEvents.HttpClient` | Outbound HTTP calls | `http.outbound.started`, `http.outbound.completed`, `http.outbound.failed` | `AddOtelEventsOutboundTracking()` |
 | `OtelEvents.Grpc` | gRPC (server + client) | `grpc.call.started`, `grpc.call.completed`, `grpc.call.failed` | `AddOtelEventsGrpc()` |
 | `OtelEvents.Azure.CosmosDb` | Azure Cosmos DB | `cosmosdb.query.executed`, `cosmosdb.query.failed`, `cosmosdb.point.read`, `cosmosdb.point.write` | `AddOtelEventsCosmosDb()` |
 | `OtelEvents.Azure.Storage` | Azure Blob + Queue Storage | `storage.blob.uploaded`, `storage.blob.downloaded`, `storage.blob.deleted`, `storage.blob.failed`, `storage.queue.sent`, `storage.queue.received`, `storage.queue.failed` | `AddOtelEventsAzureStorage()` |
@@ -23,6 +24,7 @@ Integration packs use event IDs starting at 10000 to avoid collisions with your 
 | AspNetCore | 10001–10003 |
 | Grpc | 10101–10103 |
 | CosmosDb | 10201–10204 |
+| HttpClient | 10010–10012 |
 | Azure.Storage | 10301–10307 |
 
 > **Note:** Event ID range 10401–10410 is available for consumer schemas.
@@ -421,6 +423,69 @@ builder.Services.AddOtelEventsAzureStorage(opts =>
     opts.ExcludeContainers = ["$logs"];
 });
 ```
+
+---
+
+## OtelEvents.HttpClient
+
+Automatically emits structured events for outbound HTTP calls via a `DelegatingHandler`. Works with any `IHttpClientFactory`-registered client.
+
+### Install
+
+```bash
+dotnet add package OtelEvents.HttpClient
+```
+
+### Register
+
+```csharp
+// Program.cs — register per named/typed client
+builder.Services.AddHttpClient("PaymentGateway")
+    .AddOtelEventsOutboundTracking();
+
+// Or with configuration
+builder.Services.AddHttpClient<IOrdersClient, OrdersClient>()
+    .AddOtelEventsOutboundTracking(options =>
+    {
+        options.UrlRedactor = uri => $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath}";
+    });
+```
+
+### Configure
+
+```csharp
+builder.Services.AddHttpClient("MyApi")
+    .AddOtelEventsOutboundTracking(options =>
+    {
+        // Emit http.outbound.started before each request
+        options.EmitStartedEvent = true;           // default: true
+
+        // Redact URLs before emitting (e.g., strip query params, tokens)
+        options.UrlRedactor = uri =>
+            $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath}";
+
+        // Custom failure classification (default: status >= 500)
+        options.IsFailure = response =>
+            (int)response.StatusCode >= 500 ||
+            (int)response.StatusCode == 429;
+    });
+```
+
+### Events Emitted
+
+| Event | ID | Severity | When |
+|-------|-----|----------|------|
+| `http.outbound.started` | 10010 | DEBUG | Before sending request (opt-in, default: on) |
+| `http.outbound.completed` | 10011 | DEBUG | Response received successfully |
+| `http.outbound.failed` | 10012 | ERROR | Exception thrown or response classified as failure |
+
+### `OtelEventsOutboundTrackingOptions` Reference
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `EmitStartedEvent` | `bool` | `true` | Emit start-of-request event |
+| `UrlRedactor` | `Func<Uri, string>?` | `null` | Redact URLs before emitting |
+| `IsFailure` | `Func<HttpResponseMessage, bool>?` | `null` | Custom failure classification (default: status ≥ 500) |
 
 ---
 

--- a/src/OtelEvents.HttpClient/Events/HttpOutboundEvents.cs
+++ b/src/OtelEvents.HttpClient/Events/HttpOutboundEvents.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.Logging;
+
+namespace OtelEvents.HttpClient.Events;
+
+/// <summary>
+/// Pre-compiled [LoggerMessage] methods for outbound HTTP call lifecycle events.
+/// Event IDs 10010–10012 follow the integration pack convention (10000+ range).
+/// </summary>
+/// <remarks>
+/// This code is pre-compiled in the NuGet package — consumers do NOT need
+/// OtelEvents.Schema at build time.
+/// </remarks>
+internal static partial class HttpOutboundEvents
+{
+    // ─── Event: http.outbound.started (ID 10010) ────────────────────────
+
+    [LoggerMessage(
+        EventId = 10010,
+        EventName = "http.outbound.started",
+        Level = LogLevel.Debug,
+        Message = "{httpMethod} {httpUrl} started")]
+    private static partial void LogHttpOutboundStarted(
+        ILogger logger,
+        string httpMethod,
+        string httpUrl,
+        string? httpClientName);
+
+    /// <summary>
+    /// Emits the <c>http.outbound.started</c> event (ID 10010).
+    /// </summary>
+    internal static void HttpOutboundStarted(
+        this ILogger logger,
+        string httpMethod,
+        string httpUrl,
+        string? httpClientName)
+    {
+        LogHttpOutboundStarted(logger, httpMethod, httpUrl, httpClientName);
+    }
+
+    // ─── Event: http.outbound.completed (ID 10011) ──────────────────────
+
+    [LoggerMessage(
+        EventId = 10011,
+        EventName = "http.outbound.completed",
+        Level = LogLevel.Debug,
+        Message = "{httpMethod} {httpUrl} → {httpStatusCode} in {durationMs}ms")]
+    private static partial void LogHttpOutboundCompleted(
+        ILogger logger,
+        string httpMethod,
+        string httpUrl,
+        int httpStatusCode,
+        double durationMs,
+        string? httpClientName);
+
+    /// <summary>
+    /// Emits the <c>http.outbound.completed</c> event (ID 10011).
+    /// </summary>
+    internal static void HttpOutboundCompleted(
+        this ILogger logger,
+        string httpMethod,
+        string httpUrl,
+        int httpStatusCode,
+        double durationMs,
+        string? httpClientName)
+    {
+        LogHttpOutboundCompleted(logger, httpMethod, httpUrl, httpStatusCode, durationMs, httpClientName);
+    }
+
+    // ─── Event: http.outbound.failed (ID 10012) ─────────────────────────
+
+    [LoggerMessage(
+        EventId = 10012,
+        EventName = "http.outbound.failed",
+        Level = LogLevel.Error,
+        Message = "{httpMethod} {httpUrl} failed: {errorType}")]
+    private static partial void LogHttpOutboundFailed(
+        ILogger logger,
+        Exception? exception,
+        string httpMethod,
+        string httpUrl,
+        string errorType,
+        double durationMs,
+        string? httpClientName);
+
+    /// <summary>
+    /// Emits the <c>http.outbound.failed</c> event (ID 10012).
+    /// </summary>
+    internal static void HttpOutboundFailed(
+        this ILogger logger,
+        string httpMethod,
+        string httpUrl,
+        string errorType,
+        double durationMs,
+        string? httpClientName,
+        Exception? exception = null)
+    {
+        LogHttpOutboundFailed(logger, exception, httpMethod, httpUrl, errorType, durationMs, httpClientName);
+    }
+}

--- a/src/OtelEvents.HttpClient/Events/OtelEventsHttpClientEventSource.cs
+++ b/src/OtelEvents.HttpClient/Events/OtelEventsHttpClientEventSource.cs
@@ -1,0 +1,11 @@
+namespace OtelEvents.HttpClient.Events;
+
+/// <summary>
+/// Logger category marker for outbound HTTP call lifecycle events.
+/// Used as the type parameter for <c>ILogger&lt;OtelEventsHttpClientEventSource&gt;</c>
+/// to provide a stable, distinct logger category name.
+/// </summary>
+/// <remarks>
+/// Follows the same pattern as <c>OtelEventsAspNetCoreEventSource</c> in the ASP.NET Core pack.
+/// </remarks>
+public sealed class OtelEventsHttpClientEventSource;

--- a/src/OtelEvents.HttpClient/OtelEvents.HttpClient.csproj
+++ b/src/OtelEvents.HttpClient/OtelEvents.HttpClient.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Zero-code outbound HTTP call instrumentation via DelegatingHandler with structured events</Description>
+    <NoWarn>CA1031;CA1062;CA1308;CA1822;CA2000;CA2007;CA2227;SYSLIB1015</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="OtelEvents.HttpClient.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/OtelEvents.HttpClient/OtelEventsHttpClientExtensions.cs
+++ b/src/OtelEvents.HttpClient/OtelEventsHttpClientExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OtelEvents.HttpClient.Events;
 
 namespace OtelEvents.HttpClient;
 
@@ -17,6 +18,10 @@ public static class OtelEventsHttpClientExtensions
     /// <param name="builder">The HTTP client builder to configure.</param>
     /// <param name="configure">Optional action to configure <see cref="OtelEventsOutboundTrackingOptions"/>.</param>
     /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    /// <remarks>
+    /// Options are keyed to the HttpClient name, so multiple named clients can have
+    /// independent configurations without overwriting each other.
+    /// </remarks>
     public static IHttpClientBuilder AddOtelEventsOutboundTracking(
         this IHttpClientBuilder builder,
         Action<OtelEventsOutboundTrackingOptions>? configure = null)
@@ -25,12 +30,12 @@ public static class OtelEventsHttpClientExtensions
 
         if (configure is not null)
         {
-            builder.Services.Configure(configure);
+            builder.Services.Configure<OtelEventsOutboundTrackingOptions>(builder.Name, configure);
         }
 
         builder.AddHttpMessageHandler(sp =>
         {
-            var logger = sp.GetRequiredService<ILogger<OtelEventsOutboundTrackingHandler>>();
+            var logger = sp.GetRequiredService<ILogger<OtelEventsHttpClientEventSource>>();
             var options = sp.GetRequiredService<IOptionsMonitor<OtelEventsOutboundTrackingOptions>>();
 
             return new OtelEventsOutboundTrackingHandler(logger, options, builder.Name);

--- a/src/OtelEvents.HttpClient/OtelEventsHttpClientExtensions.cs
+++ b/src/OtelEvents.HttpClient/OtelEventsHttpClientExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace OtelEvents.HttpClient;
+
+/// <summary>
+/// Extension methods for registering the OtelEvents.HttpClient outbound tracking handler
+/// with <see cref="IHttpClientBuilder"/>.
+/// </summary>
+public static class OtelEventsHttpClientExtensions
+{
+    /// <summary>
+    /// Adds the OtelEvents outbound tracking <see cref="DelegatingHandler"/> to the HTTP client pipeline.
+    /// Emits structured events for every outbound HTTP call: started, completed, and failed.
+    /// </summary>
+    /// <param name="builder">The HTTP client builder to configure.</param>
+    /// <param name="configure">Optional action to configure <see cref="OtelEventsOutboundTrackingOptions"/>.</param>
+    /// <returns>The <paramref name="builder"/> for chaining.</returns>
+    public static IHttpClientBuilder AddOtelEventsOutboundTracking(
+        this IHttpClientBuilder builder,
+        Action<OtelEventsOutboundTrackingOptions>? configure = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        if (configure is not null)
+        {
+            builder.Services.Configure(configure);
+        }
+
+        builder.AddHttpMessageHandler(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<OtelEventsOutboundTrackingHandler>>();
+            var options = sp.GetRequiredService<IOptionsMonitor<OtelEventsOutboundTrackingOptions>>();
+
+            return new OtelEventsOutboundTrackingHandler(logger, options, builder.Name);
+        });
+
+        return builder;
+    }
+}

--- a/src/OtelEvents.HttpClient/OtelEventsOutboundTrackingHandler.cs
+++ b/src/OtelEvents.HttpClient/OtelEventsOutboundTrackingHandler.cs
@@ -11,21 +11,24 @@ namespace OtelEvents.HttpClient;
 /// </summary>
 /// <remarks>
 /// The handler observes but never interferes — exceptions are always re-thrown.
+/// User-provided delegates (<see cref="OtelEventsOutboundTrackingOptions.UrlRedactor"/>
+/// and <see cref="OtelEventsOutboundTrackingOptions.IsFailure"/>) are wrapped defensively
+/// so they can never kill the request or lose the response.
 /// Register via <see cref="OtelEventsHttpClientExtensions.AddOtelEventsOutboundTracking"/>.
 /// </remarks>
 internal sealed class OtelEventsOutboundTrackingHandler : DelegatingHandler
 {
-    private readonly ILogger<OtelEventsOutboundTrackingHandler> _logger;
+    private readonly ILogger<OtelEventsHttpClientEventSource> _logger;
     private readonly OtelEventsOutboundTrackingOptions _options;
     private readonly string? _httpClientName;
 
     public OtelEventsOutboundTrackingHandler(
-        ILogger<OtelEventsOutboundTrackingHandler> logger,
+        ILogger<OtelEventsHttpClientEventSource> logger,
         IOptionsMonitor<OtelEventsOutboundTrackingOptions> options,
         string? httpClientName)
     {
         _logger = logger;
-        _options = options.CurrentValue;
+        _options = options.Get(httpClientName ?? Options.DefaultName);
         _httpClientName = httpClientName;
     }
 
@@ -70,9 +73,26 @@ internal sealed class OtelEventsOutboundTrackingHandler : DelegatingHandler
         var durationMs = sw.Elapsed.TotalMilliseconds;
 
         // Check if response should be classified as failure
-        var isFailure = _options.IsFailure is not null
-            ? _options.IsFailure(response)
-            : (int)response.StatusCode >= 500;
+        var statusCode = (int)response.StatusCode;
+        bool isFailure;
+
+        if (_options.IsFailure is not null)
+        {
+            try
+            {
+                isFailure = _options.IsFailure(response);
+            }
+            catch
+            {
+                // Defensive: user-provided delegate must never lose the response.
+                // Fall back to default classification (status >= 500).
+                isFailure = statusCode >= 500;
+            }
+        }
+        else
+        {
+            isFailure = statusCode >= 500;
+        }
 
         if (isFailure)
         {
@@ -100,6 +120,7 @@ internal sealed class OtelEventsOutboundTrackingHandler : DelegatingHandler
 
     /// <summary>
     /// Applies the configured URL redactor, or returns the absolute URI as-is.
+    /// Defensive: if the user-provided delegate throws, falls back to the raw URI.
     /// </summary>
     private string RedactUrl(Uri? requestUri)
     {
@@ -108,8 +129,20 @@ internal sealed class OtelEventsOutboundTrackingHandler : DelegatingHandler
             return "<unknown>";
         }
 
-        return _options.UrlRedactor is not null
-            ? _options.UrlRedactor(requestUri)
-            : requestUri.AbsoluteUri;
+        if (_options.UrlRedactor is not null)
+        {
+            try
+            {
+                return _options.UrlRedactor(requestUri);
+            }
+            catch
+            {
+                // Defensive: user-provided delegate must never kill the request.
+                // Fall back to the raw absolute URI.
+                return requestUri.AbsoluteUri;
+            }
+        }
+
+        return requestUri.AbsoluteUri;
     }
 }

--- a/src/OtelEvents.HttpClient/OtelEventsOutboundTrackingHandler.cs
+++ b/src/OtelEvents.HttpClient/OtelEventsOutboundTrackingHandler.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OtelEvents.HttpClient.Events;
+
+namespace OtelEvents.HttpClient;
+
+/// <summary>
+/// A <see cref="DelegatingHandler"/> that emits structured events for outbound HTTP calls.
+/// Emits up to three events per request: started (10010), completed (10011), failed (10012).
+/// </summary>
+/// <remarks>
+/// The handler observes but never interferes — exceptions are always re-thrown.
+/// Register via <see cref="OtelEventsHttpClientExtensions.AddOtelEventsOutboundTracking"/>.
+/// </remarks>
+internal sealed class OtelEventsOutboundTrackingHandler : DelegatingHandler
+{
+    private readonly ILogger<OtelEventsOutboundTrackingHandler> _logger;
+    private readonly OtelEventsOutboundTrackingOptions _options;
+    private readonly string? _httpClientName;
+
+    public OtelEventsOutboundTrackingHandler(
+        ILogger<OtelEventsOutboundTrackingHandler> logger,
+        IOptionsMonitor<OtelEventsOutboundTrackingOptions> options,
+        string? httpClientName)
+    {
+        _logger = logger;
+        _options = options.CurrentValue;
+        _httpClientName = httpClientName;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var method = request.Method.Method;
+        var url = RedactUrl(request.RequestUri);
+
+        // Emit http.outbound.started (10010)
+        if (_options.EmitStartedEvent)
+        {
+            _logger.HttpOutboundStarted(method, url, _httpClientName);
+        }
+
+        var sw = Stopwatch.StartNew();
+        HttpResponseMessage response;
+
+        try
+        {
+            response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+
+            // Emit http.outbound.failed (10012)
+            _logger.HttpOutboundFailed(
+                httpMethod: method,
+                httpUrl: url,
+                errorType: ex.GetType().Name,
+                durationMs: sw.Elapsed.TotalMilliseconds,
+                httpClientName: _httpClientName,
+                exception: ex);
+
+            throw;
+        }
+
+        sw.Stop();
+        var durationMs = sw.Elapsed.TotalMilliseconds;
+
+        // Check if response should be classified as failure
+        var isFailure = _options.IsFailure is not null
+            ? _options.IsFailure(response)
+            : (int)response.StatusCode >= 500;
+
+        if (isFailure)
+        {
+            // Emit http.outbound.failed (10012) for failure-classified responses
+            _logger.HttpOutboundFailed(
+                httpMethod: method,
+                httpUrl: url,
+                errorType: $"HTTP {(int)response.StatusCode}",
+                durationMs: durationMs,
+                httpClientName: _httpClientName);
+        }
+        else
+        {
+            // Emit http.outbound.completed (10011)
+            _logger.HttpOutboundCompleted(
+                httpMethod: method,
+                httpUrl: url,
+                httpStatusCode: (int)response.StatusCode,
+                durationMs: durationMs,
+                httpClientName: _httpClientName);
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// Applies the configured URL redactor, or returns the absolute URI as-is.
+    /// </summary>
+    private string RedactUrl(Uri? requestUri)
+    {
+        if (requestUri is null)
+        {
+            return "<unknown>";
+        }
+
+        return _options.UrlRedactor is not null
+            ? _options.UrlRedactor(requestUri)
+            : requestUri.AbsoluteUri;
+    }
+}

--- a/src/OtelEvents.HttpClient/OtelEventsOutboundTrackingOptions.cs
+++ b/src/OtelEvents.HttpClient/OtelEventsOutboundTrackingOptions.cs
@@ -1,0 +1,29 @@
+namespace OtelEvents.HttpClient;
+
+/// <summary>
+/// Configuration for the OtelEvents.HttpClient outbound tracking handler.
+/// Controls URL redaction, failure classification, and which events are emitted.
+/// </summary>
+public sealed class OtelEventsOutboundTrackingOptions
+{
+    /// <summary>
+    /// Redact URLs before emitting (e.g., strip query params).
+    /// Receives the request <see cref="Uri"/> and returns a sanitized string.
+    /// Default: null (uses <see cref="Uri.AbsoluteUri"/> as-is).
+    /// </summary>
+    public Func<Uri, string>? UrlRedactor { get; set; }
+
+    /// <summary>
+    /// Custom failure classification.
+    /// Receives the <see cref="HttpResponseMessage"/> and returns true if the response
+    /// should be classified as a failure (emits <c>http.outbound.failed</c> instead of <c>http.outbound.completed</c>).
+    /// Default: null (status &gt;= 500 is considered a failure).
+    /// </summary>
+    public Func<HttpResponseMessage, bool>? IsFailure { get; set; }
+
+    /// <summary>
+    /// Emit <c>http.outbound.started</c> event before sending the request.
+    /// Default: true.
+    /// </summary>
+    public bool EmitStartedEvent { get; set; } = true;
+}

--- a/tests/OtelEvents.HttpClient.Tests/OtelEvents.HttpClient.Tests.csproj
+++ b/tests/OtelEvents.HttpClient.Tests/OtelEvents.HttpClient.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CA1063;CA1307;CA1707;CA1816;CA1848;CA2000;CA2007;CA2213;CA2234</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="OpenTelemetry" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OtelEvents.HttpClient\OtelEvents.HttpClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OtelEvents.HttpClient.Tests/OtelEventsOutboundTrackingHandlerTests.cs
+++ b/tests/OtelEvents.HttpClient.Tests/OtelEventsOutboundTrackingHandlerTests.cs
@@ -1,0 +1,369 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace OtelEvents.HttpClient.Tests;
+
+/// <summary>
+/// Unit tests for OtelEventsOutboundTrackingHandler.
+/// Validates all three outbound HTTP lifecycle events, configuration options,
+/// failure classification, URL redaction, and duration measurement.
+/// </summary>
+public sealed class OtelEventsOutboundTrackingHandlerTests : IDisposable
+{
+    private ServiceProvider? _serviceProvider;
+
+    public void Dispose()
+    {
+        _serviceProvider?.Dispose();
+    }
+
+    // ─── Test Infrastructure ────────────────────────────────────────────
+
+    /// <summary>
+    /// Creates an HttpClient wired with the OtelEvents tracking handler and an in-memory log exporter.
+    /// The inner handler is a <see cref="FakeHttpMessageHandler"/> for controlling responses.
+    /// </summary>
+    private (System.Net.Http.HttpClient Client, TestLogExporter Exporter) CreateTestClient(
+        Action<OtelEventsOutboundTrackingOptions>? configureOptions = null,
+        FakeHttpMessageHandler? innerHandler = null,
+        string httpClientName = "TestClient")
+    {
+        var exporter = new TestLogExporter();
+
+        var services = new ServiceCollection();
+
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.ParseStateValues = true;
+                options.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+            });
+        });
+
+        services.AddHttpClient(httpClientName)
+            .AddOtelEventsOutboundTracking(configureOptions)
+            .ConfigurePrimaryHttpMessageHandler(() => innerHandler ?? new FakeHttpMessageHandler());
+
+        _serviceProvider = services.BuildServiceProvider();
+
+        var factory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
+        var client = factory.CreateClient(httpClientName);
+
+        return (client, exporter);
+    }
+
+    // ─── Successful Request Tests ───────────────────────────────────────
+
+    [Fact]
+    public async Task Successful_request_emits_completed_event_with_correct_fields()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        var record = exporter.AssertSingle("http.outbound.completed");
+        Assert.Equal(LogLevel.Debug, record.LogLevel);
+        record.AssertAttribute("httpMethod", "GET");
+        record.AssertAttribute("httpUrl", "https://api.example.com/orders");
+        record.AssertAttribute("httpStatusCode", 200);
+        record.AssertAttribute("httpClientName", "TestClient");
+        Assert.True(record.Attributes.ContainsKey("durationMs"));
+    }
+
+    [Fact]
+    public async Task Successful_request_emits_started_event_by_default()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        exporter.AssertEventEmitted("http.outbound.started");
+        var started = exporter.AssertSingle("http.outbound.started");
+        started.AssertAttribute("httpMethod", "GET");
+        started.AssertAttribute("httpUrl", "https://api.example.com/orders");
+        started.AssertAttribute("httpClientName", "TestClient");
+    }
+
+    // ─── Exception Tests ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Exception_emits_failed_event_with_exception()
+    {
+        // Arrange
+        var expectedException = new HttpRequestException("Connection refused");
+        var handler = new FakeHttpMessageHandler(expectedException);
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.GetAsync("https://api.example.com/orders"));
+
+        var record = exporter.AssertSingle("http.outbound.failed");
+        Assert.Equal(LogLevel.Error, record.LogLevel);
+        record.AssertAttribute("httpMethod", "GET");
+        record.AssertAttribute("httpUrl", "https://api.example.com/orders");
+        record.AssertAttribute("errorType", "HttpRequestException");
+        Assert.True(record.Attributes.ContainsKey("durationMs"));
+        Assert.NotNull(record.Exception);
+    }
+
+    [Fact]
+    public async Task Cancellation_emits_failed_event()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        var handler = new FakeHttpMessageHandler(new TaskCanceledException("Request timed out"));
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            client.GetAsync("https://api.example.com/orders", cts.Token));
+
+        var record = exporter.AssertSingle("http.outbound.failed");
+        record.AssertAttribute("errorType", "TaskCanceledException");
+        record.AssertAttribute("httpClientName", "TestClient");
+    }
+
+    // ─── Custom IsFailure Classification Tests ──────────────────────────
+
+    [Fact]
+    public async Task Custom_IsFailure_classifies_429_as_failure()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.TooManyRequests);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.IsFailure = response => (int)response.StatusCode == 429;
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        var record = exporter.AssertSingle("http.outbound.failed");
+        record.AssertAttribute("errorType", "HTTP 429");
+        record.AssertAttribute("httpClientName", "TestClient");
+    }
+
+    [Fact]
+    public async Task Default_failure_classification_treats_500_as_failure()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.InternalServerError);
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        exporter.AssertSingle("http.outbound.failed");
+        exporter.AssertEventNotEmitted("http.outbound.completed");
+    }
+
+    [Fact]
+    public async Task Default_failure_classification_treats_404_as_success()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.NotFound);
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        exporter.AssertSingle("http.outbound.completed");
+        exporter.AssertEventNotEmitted("http.outbound.failed");
+    }
+
+    // ─── URL Redaction Tests ────────────────────────────────────────────
+
+    [Fact]
+    public async Task UrlRedactor_strips_query_params()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.UrlRedactor = uri => $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath}";
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders?secret=123&token=abc");
+
+        // Assert
+        var record = exporter.AssertSingle("http.outbound.completed");
+        record.AssertAttribute("httpUrl", "https://api.example.com/orders");
+    }
+
+    [Fact]
+    public async Task UrlRedactor_applied_to_started_event()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.UrlRedactor = uri => $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath}";
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders?secret=123");
+
+        // Assert
+        var started = exporter.AssertSingle("http.outbound.started");
+        started.AssertAttribute("httpUrl", "https://api.example.com/orders");
+    }
+
+    // ─── EmitStartedEvent Tests ─────────────────────────────────────────
+
+    [Fact]
+    public async Task EmitStartedEvent_false_suppresses_started_event()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts => opts.EmitStartedEvent = false,
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        exporter.AssertEventNotEmitted("http.outbound.started");
+        exporter.AssertEventEmitted("http.outbound.completed");
+    }
+
+    [Fact]
+    public async Task EmitStartedEvent_true_emits_started_event()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts => opts.EmitStartedEvent = true,
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        exporter.AssertEventEmitted("http.outbound.started");
+    }
+
+    // ─── Client Name Tests ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Client_name_propagated_in_events()
+    {
+        // Arrange
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            innerHandler: handler,
+            httpClientName: "PaymentGateway");
+
+        // Act
+        await client.GetAsync("https://api.example.com/pay");
+
+        // Assert
+        var started = exporter.AssertSingle("http.outbound.started");
+        started.AssertAttribute("httpClientName", "PaymentGateway");
+
+        var completed = exporter.AssertSingle("http.outbound.completed");
+        completed.AssertAttribute("httpClientName", "PaymentGateway");
+    }
+
+    // ─── Duration Measurement Tests ─────────────────────────────────────
+
+    [Fact]
+    public async Task Duration_measured_on_completed_event()
+    {
+        // Arrange — add 50ms simulated delay
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, delay: TimeSpan.FromMilliseconds(50));
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert
+        var record = exporter.AssertSingle("http.outbound.completed");
+        var durationMs = (double)record.Attributes["durationMs"]!;
+        Assert.True(durationMs >= 40, $"Expected durationMs >= 40 but got {durationMs}");
+    }
+
+    [Fact]
+    public async Task Duration_measured_on_failed_exception_event()
+    {
+        // Arrange — add 50ms simulated delay before throwing
+        var handler = new FakeHttpMessageHandler(
+            new HttpRequestException("Timeout"),
+            delay: TimeSpan.FromMilliseconds(50));
+        var (client, exporter) = CreateTestClient(innerHandler: handler);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.GetAsync("https://api.example.com/orders"));
+
+        var record = exporter.AssertSingle("http.outbound.failed");
+        var durationMs = (double)record.Attributes["durationMs"]!;
+        Assert.True(durationMs >= 40, $"Expected durationMs >= 40 but got {durationMs}");
+    }
+}
+
+/// <summary>
+/// Fake HTTP message handler for testing. Returns a configurable response
+/// or throws a configurable exception.
+/// </summary>
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly HttpStatusCode? _statusCode;
+    private readonly Exception? _exception;
+    private readonly TimeSpan _delay;
+
+    public FakeHttpMessageHandler(HttpStatusCode statusCode = HttpStatusCode.OK, TimeSpan delay = default)
+    {
+        _statusCode = statusCode;
+        _delay = delay;
+    }
+
+    public FakeHttpMessageHandler(Exception exception, TimeSpan delay = default)
+    {
+        _exception = exception;
+        _delay = delay;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (_delay > TimeSpan.Zero)
+        {
+            await Task.Delay(_delay, cancellationToken);
+        }
+
+        if (_exception is not null)
+        {
+            throw _exception;
+        }
+
+        return new HttpResponseMessage(_statusCode ?? HttpStatusCode.OK);
+    }
+}

--- a/tests/OtelEvents.HttpClient.Tests/OtelEventsOutboundTrackingHandlerTests.cs
+++ b/tests/OtelEvents.HttpClient.Tests/OtelEventsOutboundTrackingHandlerTests.cs
@@ -291,6 +291,184 @@ public sealed class OtelEventsOutboundTrackingHandlerTests : IDisposable
         completed.AssertAttribute("httpClientName", "PaymentGateway");
     }
 
+    // ─── Defensive Delegate Tests — UrlRedactor ────────────────────────
+
+    [Fact]
+    public async Task UrlRedactor_throwing_falls_back_to_absolute_uri_on_completed()
+    {
+        // Arrange — UrlRedactor throws, should fall back to raw URI
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.UrlRedactor = _ => throw new InvalidOperationException("redactor boom");
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders?secret=123");
+
+        // Assert — request succeeds; URL falls back to AbsoluteUri
+        var record = exporter.AssertSingle("http.outbound.completed");
+        record.AssertAttribute("httpUrl", "https://api.example.com/orders?secret=123");
+    }
+
+    [Fact]
+    public async Task UrlRedactor_throwing_falls_back_to_absolute_uri_on_started()
+    {
+        // Arrange — UrlRedactor throws, started event should still emit with raw URI
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.EmitStartedEvent = true;
+                opts.UrlRedactor = _ => throw new InvalidOperationException("redactor boom");
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders?token=abc");
+
+        // Assert
+        var started = exporter.AssertSingle("http.outbound.started");
+        started.AssertAttribute("httpUrl", "https://api.example.com/orders?token=abc");
+    }
+
+    [Fact]
+    public async Task UrlRedactor_throwing_does_not_prevent_request()
+    {
+        // Arrange — even when UrlRedactor throws, the HTTP request must go through
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.UrlRedactor = _ => throw new InvalidOperationException("redactor boom");
+            },
+            innerHandler: handler);
+
+        // Act — must not throw
+        var response = await client.GetAsync("https://api.example.com/orders");
+
+        // Assert — response returned successfully
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        exporter.AssertEventEmitted("http.outbound.completed");
+    }
+
+    // ─── Defensive Delegate Tests — IsFailure ───────────────────────────
+
+    [Fact]
+    public async Task IsFailure_throwing_falls_back_to_default_treats_500_as_failure()
+    {
+        // Arrange — IsFailure throws on 500, fallback classifies as failure (>= 500)
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.InternalServerError);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.IsFailure = _ => throw new InvalidOperationException("classifier boom");
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert — classified as failure via default logic
+        exporter.AssertSingle("http.outbound.failed");
+        exporter.AssertEventNotEmitted("http.outbound.completed");
+    }
+
+    [Fact]
+    public async Task IsFailure_throwing_falls_back_to_default_treats_200_as_success()
+    {
+        // Arrange — IsFailure throws on 200, fallback classifies as success (< 500)
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.IsFailure = _ => throw new InvalidOperationException("classifier boom");
+            },
+            innerHandler: handler);
+
+        // Act
+        await client.GetAsync("https://api.example.com/orders");
+
+        // Assert — classified as success via default logic
+        exporter.AssertSingle("http.outbound.completed");
+        exporter.AssertEventNotEmitted("http.outbound.failed");
+    }
+
+    [Fact]
+    public async Task IsFailure_throwing_does_not_lose_response()
+    {
+        // Arrange — IsFailure throws, but the response must still be returned
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK);
+        var (client, exporter) = CreateTestClient(
+            configureOptions: opts =>
+            {
+                opts.IsFailure = _ => throw new InvalidOperationException("classifier boom");
+            },
+            innerHandler: handler);
+
+        // Act — must not throw
+        var response = await client.GetAsync("https://api.example.com/orders");
+
+        // Assert — response is returned intact
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // ─── Named Options Isolation Tests ──────────────────────────────────
+
+    [Fact]
+    public async Task Named_options_isolate_configurations_across_clients()
+    {
+        // Arrange — two clients with different UrlRedactor configurations
+        var exporter = new TestLogExporter();
+
+        var services = new ServiceCollection();
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddOpenTelemetry(options =>
+            {
+                options.IncludeFormattedMessage = true;
+                options.ParseStateValues = true;
+                options.AddProcessor(new SimpleLogRecordExportProcessor(exporter));
+            });
+        });
+
+        // ClientA: strips query params
+        services.AddHttpClient("ClientA")
+            .AddOtelEventsOutboundTracking(opts =>
+            {
+                opts.UrlRedactor = uri => $"{uri.Scheme}://{uri.Host}{uri.AbsolutePath}";
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new FakeHttpMessageHandler());
+
+        // ClientB: no redaction (default)
+        services.AddHttpClient("ClientB")
+            .AddOtelEventsOutboundTracking()
+            .ConfigurePrimaryHttpMessageHandler(() => new FakeHttpMessageHandler());
+
+        using var sp = services.BuildServiceProvider();
+        var factory = sp.GetRequiredService<IHttpClientFactory>();
+        var clientA = factory.CreateClient("ClientA");
+        var clientB = factory.CreateClient("ClientB");
+
+        // Act
+        await clientA.GetAsync("https://api.example.com/orders?secret=123");
+        await clientB.GetAsync("https://api.example.com/orders?secret=456");
+
+        // Assert — each client uses its own options
+        var completed = exporter.LogRecords.Where(r => r.EventName == "http.outbound.completed").ToList();
+        Assert.Equal(2, completed.Count);
+
+        var recordA = completed.First(r => r.Attributes["httpClientName"]?.ToString() == "ClientA");
+        recordA.AssertAttribute("httpUrl", "https://api.example.com/orders");
+
+        var recordB = completed.First(r => r.Attributes["httpClientName"]?.ToString() == "ClientB");
+        recordB.AssertAttribute("httpUrl", "https://api.example.com/orders?secret=456");
+    }
+
     // ─── Duration Measurement Tests ─────────────────────────────────────
 
     [Fact]

--- a/tests/OtelEvents.HttpClient.Tests/TestLogExporter.cs
+++ b/tests/OtelEvents.HttpClient.Tests/TestLogExporter.cs
@@ -1,0 +1,127 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Logs;
+
+namespace OtelEvents.HttpClient.Tests;
+
+/// <summary>
+/// In-memory OTEL LogRecord collector for testing.
+/// Captures immutable snapshots of LogRecords for safe assertions.
+/// </summary>
+internal sealed class TestLogExporter : BaseExporter<LogRecord>
+{
+    private readonly ConcurrentQueue<TestLogRecord> _records = new();
+
+    /// <summary>Gets all captured log records as a list in chronological order.</summary>
+    public IReadOnlyList<TestLogRecord> LogRecords => _records.ToArray().ToList();
+
+    public override ExportResult Export(in Batch<LogRecord> batch)
+    {
+        foreach (var record in batch)
+        {
+            _records.Enqueue(TestLogRecord.From(record));
+        }
+
+        return ExportResult.Success;
+    }
+
+    /// <summary>Asserts that at least one record with the specified event name was emitted.</summary>
+    public void AssertEventEmitted(string eventName)
+    {
+        var found = LogRecords.Any(r => r.EventName == eventName);
+        if (!found)
+        {
+            var emittedEvents = LogRecords.Count > 0
+                ? string.Join(", ", LogRecords.Select(r => $"'{r.EventName}'"))
+                : "(none)";
+            throw new Xunit.Sdk.XunitException(
+                $"Expected event '{eventName}' to be emitted, but it was not found. Emitted events: {emittedEvents}");
+        }
+    }
+
+    /// <summary>Asserts that no record with the specified event name was emitted.</summary>
+    public void AssertEventNotEmitted(string eventName)
+    {
+        var found = LogRecords.Any(r => r.EventName == eventName);
+        if (found)
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"Expected event '{eventName}' NOT to be emitted, but it was found.");
+        }
+    }
+
+    /// <summary>Asserts exactly one record with the specified event name and returns it.</summary>
+    public TestLogRecord AssertSingle(string eventName)
+    {
+        var matches = LogRecords.Where(r => r.EventName == eventName).ToList();
+        if (matches.Count == 0)
+        {
+            var emittedEvents = LogRecords.Count > 0
+                ? string.Join(", ", LogRecords.Select(r => $"'{r.EventName}'"))
+                : "(none)";
+            throw new Xunit.Sdk.XunitException(
+                $"Expected exactly one '{eventName}' event, but found none. Emitted events: {emittedEvents}");
+        }
+        if (matches.Count > 1)
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"Expected exactly one '{eventName}' event, but found {matches.Count}.");
+        }
+        return matches[0];
+    }
+}
+
+/// <summary>
+/// Immutable snapshot of a LogRecord for test assertions.
+/// </summary>
+internal sealed class TestLogRecord
+{
+    public string? EventName { get; init; }
+    public EventId EventId { get; init; }
+    public LogLevel LogLevel { get; init; }
+    public string? FormattedMessage { get; init; }
+    public Exception? Exception { get; init; }
+    public IReadOnlyDictionary<string, object?> Attributes { get; init; } = new Dictionary<string, object?>();
+
+    public static TestLogRecord From(LogRecord record)
+    {
+        var attrs = new Dictionary<string, object?>();
+        if (record.Attributes is not null)
+        {
+            foreach (var kvp in record.Attributes)
+            {
+                attrs[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return new TestLogRecord
+        {
+            EventName = record.EventId.Name,
+            EventId = record.EventId,
+            LogLevel = record.LogLevel,
+            FormattedMessage = record.FormattedMessage,
+            Exception = record.Exception,
+            Attributes = attrs
+        };
+    }
+
+    /// <summary>Asserts that the record contains an attribute with the specified key and expected value.</summary>
+    public void AssertAttribute(string key, object? expected)
+    {
+        if (!Attributes.TryGetValue(key, out var actual))
+        {
+            var availableKeys = Attributes.Count > 0
+                ? string.Join(", ", Attributes.Keys.Select(k => $"'{k}'"))
+                : "(none)";
+            throw new Xunit.Sdk.XunitException(
+                $"Expected attribute '{key}' not found. Available attributes: {availableKeys}");
+        }
+        if (!Equals(actual, expected))
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"Attribute '{key}' expected value '{expected}' (type: {expected?.GetType().Name ?? "null"}) " +
+                $"but found '{actual}' (type: {actual?.GetType().Name ?? "null"}).");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements #47 — new **OtelEvents.HttpClient** integration pack that tracks outbound HTTP calls as structured events via a `DelegatingHandler`.

## What's included

### New package: `OtelEvents.HttpClient`

| File | Purpose |
|------|---------|
| `OtelEventsOutboundTrackingOptions.cs` | URL redaction, failure classification, started event toggle |
| `Events/HttpOutboundEvents.cs` | `[LoggerMessage]` event source (IDs 10010–10012) |
| `OtelEventsOutboundTrackingHandler.cs` | `DelegatingHandler` emitting lifecycle events |
| `OtelEventsHttpClientExtensions.cs` | `IHttpClientBuilder.AddOtelEventsOutboundTracking()` extension |

### Events emitted

| Event | ID | Severity | When |
|-------|-----|----------|------|
| `http.outbound.started` | 10010 | Debug | Before sending request (configurable) |
| `http.outbound.completed` | 10011 | Debug | Response received successfully |
| `http.outbound.failed` | 10012 | Error | Exception thrown or response classified as failure |

### Tests (12 cases)

- ✅ Successful request → `completed` event with correct fields
- ✅ Exception → `failed` event with exception details
- ✅ Cancellation → `failed` event with TaskCanceledException
- ✅ Custom `IsFailure` classification (429 as failure)
- ✅ Default failure classification (500+ as failure, 404 as success)
- ✅ URL redaction (query params stripped)
- ✅ `EmitStartedEvent = false` suppresses started event
- ✅ `EmitStartedEvent = true` emits started event
- ✅ Client name propagated in all events
- ✅ Duration measurement (completed + failed paths)

### Docs updated

- `README.md` — added to package table and installation section
- `docs/user-guide/06-integration-packs.md` — added HttpClient section with registration, configuration, events, and options reference

### Build

```
Build succeeded. 0 Warning(s) 0 Error(s)
```

> **Note:** Unit tests cannot execute in CI until .NET 8 runtime is available (projects target net8.0, environment has .NET 10 SDK only). Build compiles all test code successfully.

Closes #47