### PR TITLE
feat: add OtelEvents.Health.AspNetCore — K8s probe endpoints (#57)

### DIFF
--- a/OtelEvents.slnx
+++ b/OtelEvents.slnx
@@ -10,7 +10,7 @@
     <Project Path="src/OtelEvents.Grpc/OtelEvents.Grpc.csproj" />
     <Project Path="src/OtelEvents.HttpClient/OtelEvents.HttpClient.csproj" />
     <Project Path="src/OtelEvents.Health/OtelEvents.Health.csproj" />
-    <Project Path="src/OtelEvents.Health.Grpc/OtelEvents.Health.Grpc.csproj" />
+    <Project Path="src/OtelEvents.Health.AspNetCore/OtelEvents.Health.AspNetCore.csproj" />
 
     <Project Path="src/OtelEvents.Schema/OtelEvents.Schema.csproj" />
     <Project Path="src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj" />
@@ -27,7 +27,7 @@
     <Project Path="tests/OtelEvents.Grpc.Tests/OtelEvents.Grpc.Tests.csproj" />
     <Project Path="tests/OtelEvents.HttpClient.Tests/OtelEvents.HttpClient.Tests.csproj" />
     <Project Path="tests/OtelEvents.Health.Tests/OtelEvents.Health.Tests.csproj" />
-    <Project Path="tests/OtelEvents.Health.Grpc.Tests/OtelEvents.Health.Grpc.Tests.csproj" />
+    <Project Path="tests/OtelEvents.Health.AspNetCore.Tests/OtelEvents.Health.AspNetCore.Tests.csproj" />
 
     <Project Path="tests/OtelEvents.Schema.Tests/OtelEvents.Schema.Tests.csproj" />
     <Project Path="tests/OtelEvents.Subscriptions.Tests/OtelEvents.Subscriptions.Tests.csproj" />

--- a/src/OtelEvents.Health.AspNetCore/OtelEvents.Health.AspNetCore.csproj
+++ b/src/OtelEvents.Health.AspNetCore/OtelEvents.Health.AspNetCore.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>OtelEvents.Health.AspNetCore</RootNamespace>
+    <AssemblyName>OtelEvents.Health.AspNetCore</AssemblyName>
+    <Description>OtelEvents Health ASP.NET Core — K8s health probe endpoints</Description>
+    <NoWarn>CA1031</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OtelEvents.Health\OtelEvents.Health.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="OtelEvents.Health.AspNetCore.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/src/OtelEvents.Health.AspNetCore/OtelEventsHealthEndpointExtensions.cs
+++ b/src/OtelEvents.Health.AspNetCore/OtelEventsHealthEndpointExtensions.cs
@@ -1,0 +1,55 @@
+using OtelEvents.Health;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OtelEvents.Health.AspNetCore;
+
+/// <summary>
+/// Extension methods for mapping OtelEvents Health probe endpoints.
+/// </summary>
+public static class OtelEventsHealthEndpointExtensions
+{
+    /// <summary>
+    /// Maps K8s health probe endpoints (liveness, readiness, startup).
+    /// <para>
+    /// Requires <see cref="OtelEvents.Health.IHealthReportProvider"/> and <see cref="OtelEvents.Health.IStartupTracker"/>
+    /// to be registered in the dependency injection container (via <c>AddOtelEventsHealth()</c>).
+    /// </para>
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <param name="configure">Optional configuration for endpoint paths and default detail level.</param>
+    /// <returns>The endpoint route builder for chaining.</returns>
+    public static IEndpointRouteBuilder MapHealthEndpoints(
+        this IEndpointRouteBuilder endpoints,
+        Action<OtelEventsHealthEndpointOptions>? configure = null)
+    {
+        var options = new OtelEventsHealthEndpointOptions();
+        configure?.Invoke(options);
+
+        var detailLevel = options.DefaultDetailLevel;
+
+        endpoints.MapGet(options.LivenessPath, (OtelEvents.Health.IHealthReportProvider provider) =>
+            ProbeEndpointHandler.HandleLiveness(provider, detailLevel))
+            .ExcludeFromDescription();
+
+        endpoints.MapGet(options.ReadinessPath, (OtelEvents.Health.IHealthReportProvider provider) =>
+            ProbeEndpointHandler.HandleReadiness(provider, detailLevel))
+            .ExcludeFromDescription();
+
+        endpoints.MapGet(options.StartupPath, (OtelEvents.Health.IStartupTracker tracker) =>
+            ProbeEndpointHandler.HandleStartup(tracker))
+            .ExcludeFromDescription();
+
+        endpoints.MapGet(options.TenantHealthPath, (
+            OtelEvents.Health.IHealthReportProvider provider,
+            HttpContext context) =>
+        {
+            var tenantProvider = context.RequestServices.GetService<ITenantHealthProvider>();
+            return TenantHealthEndpointHandler.HandleTenantHealth(tenantProvider, provider, detailLevel);
+        }).ExcludeFromDescription();
+
+        return endpoints;
+    }
+}

--- a/src/OtelEvents.Health.AspNetCore/OtelEventsHealthEndpointOptions.cs
+++ b/src/OtelEvents.Health.AspNetCore/OtelEventsHealthEndpointOptions.cs
@@ -1,0 +1,52 @@
+using OtelEvents.Health.Contracts;
+
+namespace OtelEvents.Health.AspNetCore;
+
+/// <summary>
+/// Configuration options for OtelEvents Health probe endpoints.
+/// </summary>
+public sealed class OtelEventsHealthEndpointOptions
+{
+    /// <summary>
+    /// Path for the liveness probe. Default: <c>/healthz/live</c>.
+    /// </summary>
+    public string LivenessPath { get; set; } = "/healthz/live";
+
+    /// <summary>
+    /// Path for the readiness probe. Default: <c>/healthz/ready</c>.
+    /// </summary>
+    public string ReadinessPath { get; set; } = "/healthz/ready";
+
+    /// <summary>
+    /// Path for the startup probe. Default: <c>/healthz/startup</c>.
+    /// </summary>
+    public string StartupPath { get; set; } = "/healthz/startup";
+
+    /// <summary>
+    /// Path for the tenant health endpoint. Default: <c>/healthz/tenants</c>.
+    /// <para>
+    /// This endpoint is only accessible at <see cref="DetailLevel.Full"/>.
+    /// Lower detail levels return 403 Forbidden (Security Finding #6).
+    /// <b>This endpoint should be behind authentication in production.</b>
+    /// </para>
+    /// </summary>
+    public string TenantHealthPath { get; set; } = "/healthz/tenants";
+
+    /// <summary>
+    /// Default detail level for probe responses.
+    /// <see cref="DetailLevel.StatusOnly"/> is the default (Security Finding #1 — CRITICAL).
+    /// K8s probes only need HTTP status codes; minimal bodies reduce information leakage.
+    /// </summary>
+    /// <remarks>
+    /// <b>Production hardening:</b> All health endpoints are registered without
+    /// authorization by default. In production, apply authentication and authorization
+    /// by chaining <c>RequireAuthorization()</c> on the endpoint group:
+    /// <code>
+    /// app.MapHealthEndpoints(options)
+    ///    .RequireAuthorization("HealthOpsPolicy");
+    /// </code>
+    /// For Kubernetes liveness/readiness probes, consider excluding those paths
+    /// from the authorization policy via a tag or separate mapping.
+    /// </remarks>
+    public DetailLevel DefaultDetailLevel { get; set; } = DetailLevel.StatusOnly;
+}

--- a/src/OtelEvents.Health.AspNetCore/ProbeEndpointHandler.cs
+++ b/src/OtelEvents.Health.AspNetCore/ProbeEndpointHandler.cs
@@ -1,0 +1,66 @@
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace OtelEvents.Health.AspNetCore;
+
+/// <summary>
+/// Handles K8s health probe HTTP requests.
+/// Maps health data to HTTP status codes and JSON responses.
+/// </summary>
+internal static class ProbeEndpointHandler
+{
+    private const string JsonContentType = "application/json";
+
+    internal static IResult HandleLiveness(
+        OtelEvents.Health.IHealthReportProvider provider,
+        DetailLevel detailLevel)
+    {
+        try
+        {
+            var report = provider.GetHealthReport();
+            var statusCode = ProbeResponseWriter.GetLivenessStatusCode(report.Status);
+            var json = ProbeResponseWriter.WriteLivenessResponse(report, detailLevel);
+            return Results.Text(json, JsonContentType, statusCode: statusCode);
+        }
+        catch
+        {
+            var json = ProbeResponseWriter.WriteErrorResponse();
+            return Results.Text(json, JsonContentType, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    internal static IResult HandleReadiness(
+        OtelEvents.Health.IHealthReportProvider provider,
+        DetailLevel detailLevel)
+    {
+        try
+        {
+            var report = provider.GetReadinessReport();
+            var statusCode = ProbeResponseWriter.GetReadinessStatusCode(report.Status);
+            var json = ProbeResponseWriter.WriteReadinessResponse(report, detailLevel);
+            return Results.Text(json, JsonContentType, statusCode: statusCode);
+        }
+        catch
+        {
+            var json = ProbeResponseWriter.WriteErrorResponse();
+            return Results.Text(json, JsonContentType, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+
+    internal static IResult HandleStartup(OtelEvents.Health.IStartupTracker tracker)
+    {
+        try
+        {
+            var status = tracker.Status;
+            var statusCode = ProbeResponseWriter.GetStartupStatusCode(status);
+            var json = ProbeResponseWriter.WriteStartupResponse(status);
+            return Results.Text(json, JsonContentType, statusCode: statusCode);
+        }
+        catch
+        {
+            var json = ProbeResponseWriter.WriteErrorResponse();
+            return Results.Text(json, JsonContentType, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+}

--- a/src/OtelEvents.Health.AspNetCore/ProbeResponseWriter.cs
+++ b/src/OtelEvents.Health.AspNetCore/ProbeResponseWriter.cs
@@ -1,0 +1,148 @@
+using System.Text.Json;
+using OtelEvents.Health.Contracts;
+
+namespace OtelEvents.Health.AspNetCore;
+
+/// <summary>
+/// Serializes health probe data to JSON with snake_case keys.
+/// </summary>
+internal static class ProbeResponseWriter
+{
+    internal static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = false,
+    };
+
+    // ── Liveness ──────────────────────────────────────────────
+
+    internal static string WriteLivenessResponse(HealthReport report, DetailLevel level)
+    {
+        object body = level switch
+        {
+            DetailLevel.Summary => CreateLivenessSummary(report),
+            DetailLevel.Full => CreateLivenessFull(report),
+            _ => new StatusOnlyResponse(ToSnakeCaseString(report.Status)),
+        };
+
+        return JsonSerializer.Serialize(body, body.GetType(), JsonOptions);
+    }
+
+    internal static int GetLivenessStatusCode(HealthStatus status) =>
+        status == HealthStatus.Unhealthy ? 503 : 200;
+
+    // ── Readiness ─────────────────────────────────────────────
+
+    internal static string WriteReadinessResponse(ReadinessReport report, DetailLevel level)
+    {
+        object body = level switch
+        {
+            DetailLevel.Summary => CreateReadinessSummary(report),
+            DetailLevel.Full => CreateReadinessFull(report),
+            _ => new StatusOnlyResponse(ToSnakeCaseString(report.Status)),
+        };
+
+        return JsonSerializer.Serialize(body, body.GetType(), JsonOptions);
+    }
+
+    internal static int GetReadinessStatusCode(ReadinessStatus status) =>
+        status == ReadinessStatus.NotReady ? 503 : 200;
+
+    // ── Startup ───────────────────────────────────────────────
+
+    internal static string WriteStartupResponse(StartupStatus status)
+    {
+        var body = new StatusOnlyResponse(ToSnakeCaseString(status));
+        return JsonSerializer.Serialize(body, JsonOptions);
+    }
+
+    internal static int GetStartupStatusCode(StartupStatus status) =>
+        status == StartupStatus.Failed ? 503 : 200;
+
+    // ── Error ─────────────────────────────────────────────────
+
+    internal static string WriteErrorResponse()
+    {
+        var body = new StatusOnlyResponse("unhealthy");
+        return JsonSerializer.Serialize(body, JsonOptions);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────
+
+    private static string ToSnakeCaseString<T>(T value) where T : struct, Enum =>
+        JsonNamingPolicy.SnakeCaseLower.ConvertName(value.ToString());
+
+    private static LivenessSummaryResponse CreateLivenessSummary(HealthReport report) =>
+        new(
+            ToSnakeCaseString(report.Status),
+            report.Dependencies.Select(d => new DependencySummaryEntry(
+                d.DependencyId.ToString(),
+                ToSnakeCaseString(d.CurrentState))).ToList());
+
+    private static LivenessFullResponse CreateLivenessFull(HealthReport report) =>
+        new(
+            ToSnakeCaseString(report.Status),
+            report.Dependencies.Select(d => new DependencyFullEntry(
+                d.DependencyId.ToString(),
+                ToSnakeCaseString(d.CurrentState),
+                d.LatestAssessment.SuccessRate,
+                d.LatestAssessment.TotalSignals,
+                d.LatestAssessment.FailureCount,
+                d.LatestAssessment.SuccessCount)).ToList());
+
+    private static ReadinessSummaryResponse CreateReadinessSummary(ReadinessReport report) =>
+        new(
+            ToSnakeCaseString(report.Status),
+            ToSnakeCaseString(report.StartupStatus),
+            ToSnakeCaseString(report.DrainStatus),
+            report.Dependencies.Select(d => new DependencySummaryEntry(
+                d.DependencyId.ToString(),
+                ToSnakeCaseString(d.CurrentState))).ToList());
+
+    private static ReadinessFullResponse CreateReadinessFull(ReadinessReport report) =>
+        new(
+            ToSnakeCaseString(report.Status),
+            ToSnakeCaseString(report.StartupStatus),
+            ToSnakeCaseString(report.DrainStatus),
+            report.Dependencies.Select(d => new DependencyFullEntry(
+                d.DependencyId.ToString(),
+                ToSnakeCaseString(d.CurrentState),
+                d.LatestAssessment.SuccessRate,
+                d.LatestAssessment.TotalSignals,
+                d.LatestAssessment.FailureCount,
+                d.LatestAssessment.SuccessCount)).ToList());
+
+    // ── Response DTOs (internal for testability) ──────────────
+
+    internal sealed record StatusOnlyResponse(string Status);
+
+    internal sealed record LivenessSummaryResponse(
+        string Status,
+        IReadOnlyList<DependencySummaryEntry> Dependencies);
+
+    internal sealed record LivenessFullResponse(
+        string Status,
+        IReadOnlyList<DependencyFullEntry> Dependencies);
+
+    internal sealed record ReadinessSummaryResponse(
+        string Status,
+        string StartupStatus,
+        string DrainStatus,
+        IReadOnlyList<DependencySummaryEntry> Dependencies);
+
+    internal sealed record ReadinessFullResponse(
+        string Status,
+        string StartupStatus,
+        string DrainStatus,
+        IReadOnlyList<DependencyFullEntry> Dependencies);
+
+    internal sealed record DependencySummaryEntry(string Name, string State);
+
+    internal sealed record DependencyFullEntry(
+        string Name,
+        string State,
+        double SuccessRate,
+        int TotalSignals,
+        int FailureCount,
+        int SuccessCount);
+}

--- a/src/OtelEvents.Health.AspNetCore/TenantHealthEndpointHandler.cs
+++ b/src/OtelEvents.Health.AspNetCore/TenantHealthEndpointHandler.cs
@@ -1,0 +1,53 @@
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+using Microsoft.AspNetCore.Http;
+
+namespace OtelEvents.Health.AspNetCore;
+
+/// <summary>
+/// Handles tenant health HTTP requests.
+/// Returns per-tenant health data only at <see cref="DetailLevel.Full"/>;
+/// returns 403 Forbidden at lower detail levels (Security Finding #6).
+/// </summary>
+internal static class TenantHealthEndpointHandler
+{
+    private const string JsonContentType = "application/json";
+
+    /// <summary>
+    /// Handles a tenant health request for all registered components.
+    /// </summary>
+    /// <param name="provider">The optional tenant health provider (may be null if not registered).</param>
+    /// <param name="reportProvider">The health report provider for component enumeration.</param>
+    /// <param name="detailLevel">The configured detail level.</param>
+    /// <returns>An <see cref="IResult"/> containing the tenant health response.</returns>
+    internal static IResult HandleTenantHealth(
+        ITenantHealthProvider? provider,
+        OtelEvents.Health.IHealthReportProvider reportProvider,
+        DetailLevel detailLevel)
+    {
+        if (detailLevel != DetailLevel.Full)
+        {
+            return Results.Text(
+                TenantHealthResponseWriter.WriteForbiddenResponse(),
+                JsonContentType,
+                statusCode: StatusCodes.Status403Forbidden);
+        }
+
+        try
+        {
+            var report = reportProvider.GetHealthReport();
+            var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+            return Results.Text(json, JsonContentType, statusCode: StatusCodes.Status200OK);
+        }
+        catch (OperationCanceledException)
+        {
+            // Let request cancellation propagate — the host pipeline handles it.
+            throw;
+        }
+        catch (Exception)
+        {
+            var json = ProbeResponseWriter.WriteErrorResponse();
+            return Results.Text(json, JsonContentType, statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+    }
+}

--- a/src/OtelEvents.Health.AspNetCore/TenantHealthResponseWriter.cs
+++ b/src/OtelEvents.Health.AspNetCore/TenantHealthResponseWriter.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+
+namespace OtelEvents.Health.AspNetCore;
+
+/// <summary>
+/// Serializes tenant health data to JSON with snake_case keys.
+/// </summary>
+internal static class TenantHealthResponseWriter
+{
+    // ── Tenant Health ─────────────────────────────────────────
+
+    /// <summary>
+    /// Writes the tenant health response for all components in the health report.
+    /// Each component includes its active tenant count and per-tenant breakdown.
+    /// </summary>
+    /// <param name="report">The current health report for component enumeration.</param>
+    /// <param name="provider">The optional tenant health provider. When null, returns empty tenant data.</param>
+    /// <returns>A JSON string with tenant health data.</returns>
+    internal static string WriteTenantHealthResponse(
+        HealthReport report,
+        ITenantHealthProvider? provider)
+    {
+        var components = report.Dependencies.Select(dep =>
+            CreateComponentTenantResponse(dep.DependencyId, provider)).ToList();
+
+        var body = new TenantHealthResponse(components);
+        return JsonSerializer.Serialize(body, body.GetType(), ProbeResponseWriter.JsonOptions);
+    }
+
+    /// <summary>
+    /// Writes the 403 Forbidden response for non-Full detail levels.
+    /// </summary>
+    /// <returns>A JSON string with the error message.</returns>
+    internal static string WriteForbiddenResponse()
+    {
+        var body = new ForbiddenResponse("tenant_health_requires_full_detail_level");
+        return JsonSerializer.Serialize(body, body.GetType(), ProbeResponseWriter.JsonOptions);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────
+
+    private static string ToSnakeCaseString<T>(T value) where T : struct, Enum =>
+        JsonNamingPolicy.SnakeCaseLower.ConvertName(value.ToString());
+
+    private static ComponentTenantEntry CreateComponentTenantResponse(
+        DependencyId component,
+        ITenantHealthProvider? provider)
+    {
+        if (provider is null)
+        {
+            return new ComponentTenantEntry(
+                component.ToString(),
+                ActiveTenants: 0,
+                Tenants: []);
+        }
+
+        var activeTenantCount = provider.ActiveTenantCount(component);
+        var tenantHealth = provider.GetAllTenantHealth(component);
+
+        var tenantEntries = tenantHealth?.Select(kvp => new TenantEntry(
+            kvp.Key.ToString(),
+            ToSnakeCaseString(kvp.Value.Status),
+            kvp.Value.SuccessRate,
+            kvp.Value.TotalSignals,
+            kvp.Value.FailureCount)).ToList()
+            ?? [];
+
+        return new ComponentTenantEntry(
+            component.ToString(),
+            activeTenantCount,
+            tenantEntries);
+    }
+
+    // ── Response DTOs (internal for testability) ──────────────
+
+    internal sealed record TenantHealthResponse(
+        IReadOnlyList<ComponentTenantEntry> Components);
+
+    internal sealed record ComponentTenantEntry(
+        string Component,
+        int ActiveTenants,
+        IReadOnlyList<TenantEntry> Tenants);
+
+    internal sealed record TenantEntry(
+        string TenantId,
+        string Status,
+        double SuccessRate,
+        int TotalSignals,
+        int FailureCount);
+
+    internal sealed record ForbiddenResponse(string Error);
+}

--- a/tests/OtelEvents.Health.AspNetCore.Tests/EdgeCases/ProbeEndpointEdgeCaseTests.cs
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/EdgeCases/ProbeEndpointEdgeCaseTests.cs
@@ -1,0 +1,333 @@
+using System.Net;
+using FluentAssertions;
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using static OtelEvents.Health.AspNetCore.Tests.TestFixtures;
+
+namespace OtelEvents.Health.AspNetCore.Tests.EdgeCases;
+
+/// <summary>
+/// Edge case tests for probe endpoints:
+/// Empty dependency lists, all-CircuitOpen, concurrent startup transitions.
+/// </summary>
+public sealed class ProbeEndpointEdgeCaseTests : IAsyncDisposable
+{
+    private readonly List<IAsyncDisposable> _disposables = [];
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var disposable in _disposables)
+        {
+            await disposable.DisposeAsync();
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // [EDGE] No components registered (empty dependencies)
+    // ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Liveness probe with no components registered returns 200/healthy.
+    /// K8s scenario: pod starts before any dependency monitors are configured.
+    /// </summary>
+    [Fact]
+    public async Task Liveness_with_no_components_returns_200_healthy()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = CreateEmptyReport(HealthStatus.Healthy),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("healthy");
+    }
+
+    /// <summary>
+    /// Readiness probe with no dependencies returns 200/ready.
+    /// </summary>
+    [Fact]
+    public async Task Readiness_with_no_components_returns_200_ready()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            ReadinessReport = new ReadinessReport(
+                ReadinessStatus.Ready,
+                Array.Empty<DependencySnapshot>(),
+                BaseTime,
+                StartupStatus.Ready,
+                DrainStatus.Idle),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/ready");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    /// <summary>
+    /// Summary detail level with no dependencies shows empty array.
+    /// </summary>
+    [Fact]
+    public async Task Summary_detail_with_no_components_shows_empty_dependencies()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = CreateEmptyReport(HealthStatus.Healthy),
+        };
+        await using var env = await CreateTestEnv(provider, configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Summary;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().Contain("dependencies");
+        body.Should().Contain("[]"); // empty array in JSON
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // [EDGE] All components in CircuitOpen state
+    // ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// All components in CircuitOpen → liveness returns 503/unhealthy.
+    /// </summary>
+    [Fact]
+    public async Task Liveness_with_all_components_circuit_open_returns_503()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = CreateAllCircuitOpenReport(),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        body.Should().Contain("unhealthy");
+    }
+
+    /// <summary>
+    /// All components CircuitOpen → readiness returns 503/not_ready.
+    /// </summary>
+    [Fact]
+    public async Task Readiness_with_all_components_circuit_open_returns_503()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            ReadinessReport = new ReadinessReport(
+                ReadinessStatus.NotReady,
+                CreateAllCircuitOpenDependencies(),
+                BaseTime,
+                StartupStatus.Ready,
+                DrainStatus.Idle),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/ready");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    /// <summary>
+    /// Summary detail with all CircuitOpen shows correct states.
+    /// </summary>
+    [Fact]
+    public async Task Summary_detail_with_all_circuit_open_shows_all_as_circuit_open()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = CreateAllCircuitOpenReport(),
+        };
+        await using var env = await CreateTestEnv(provider, configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Summary;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        body.Should().Contain("circuit_open");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // [EDGE] Concurrent StartupTracker access
+    // ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Multiple threads calling MarkReady concurrently — volatile field
+    /// guarantees visibility, no exceptions.
+    /// </summary>
+    [Fact]
+    public async Task StartupTracker_concurrent_MarkReady_does_not_throw()
+    {
+        var tracker = new FakeStartupTracker();
+
+        // Act — 20 parallel calls to MarkReady
+        var tasks = Enumerable.Range(0, 20)
+            .Select(_ => Task.Run(() => tracker.MarkReady()))
+            .ToArray();
+
+        await Task.WhenAll(tasks);
+
+        // Assert — final status is Ready
+        tracker.Status.Should().Be(StartupStatus.Ready);
+    }
+
+    /// <summary>
+    /// Concurrent MarkReady and MarkFailed — last writer wins
+    /// with volatile. Final state should be one of the two valid end states.
+    /// </summary>
+    [Fact]
+    public async Task StartupTracker_concurrent_ready_and_failed_reaches_valid_end_state()
+    {
+        var tracker = new FakeStartupTracker();
+
+        // Act — racing MarkReady and MarkFailed
+        var readyTasks = Enumerable.Range(0, 10)
+            .Select(_ => Task.Run(() => tracker.MarkReady()))
+            .ToArray();
+        var failTasks = Enumerable.Range(0, 10)
+            .Select(_ => Task.Run(() => tracker.MarkFailed()))
+            .ToArray();
+
+        await Task.WhenAll(readyTasks.Concat(failTasks));
+
+        // Assert — status should be one of the two valid end states
+        tracker.Status.Should().BeOneOf(
+            [StartupStatus.Ready, StartupStatus.Failed],
+            "last writer wins; final state depends on thread scheduling");
+    }
+
+    /// <summary>
+    /// Reading Status while writers are updating doesn't throw.
+    /// </summary>
+    [Fact]
+    public async Task StartupTracker_concurrent_read_and_write_does_not_throw()
+    {
+        var tracker = new FakeStartupTracker();
+        var statuses = new System.Collections.Concurrent.ConcurrentBag<StartupStatus>();
+
+        // Act — readers and writers in parallel
+        var writerTask = Task.Run(() =>
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    tracker.MarkReady();
+                }
+                else
+                {
+                    tracker.MarkFailed();
+                }
+            }
+        });
+
+        var readerTask = Task.Run(() =>
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                statuses.Add(tracker.Status);
+            }
+        });
+
+        await Task.WhenAll(writerTask, readerTask);
+
+        // Assert — all observed statuses are valid enum values
+        statuses.Should().OnlyContain(s =>
+            s == StartupStatus.Starting ||
+            s == StartupStatus.Ready ||
+            s == StartupStatus.Failed);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // [EDGE] Single dependency degraded, rest healthy
+    // ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// One component Degraded among 3 Healthy → liveness returns 200 (degraded is still alive).
+    /// </summary>
+    [Fact]
+    public async Task Liveness_single_degraded_among_healthy_returns_200()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = new HealthReport(
+                HealthStatus.Degraded,
+                [
+                    CreateSnapshot(new DependencyId("svc-a"), HealthState.Healthy, 0.99, 100, 1, 99),
+                    CreateSnapshot(new DependencyId("svc-b"), HealthState.Degraded, 0.85, 100, 15, 85),
+                    CreateSnapshot(new DependencyId("svc-c"), HealthState.Healthy, 1.0, 50, 0, 50),
+                ],
+                BaseTime),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK,
+            "Degraded is still alive — K8s should NOT restart the pod");
+    }
+
+    // ─── Test Infrastructure ───────────────────────────────────
+
+    private async Task<TestEnv> CreateTestEnv(
+        OtelEvents.Health.IHealthReportProvider? provider = null,
+        OtelEvents.Health.IStartupTracker? tracker = null,
+        Action<OtelEventsHealthEndpointOptions>? configure = null)
+    {
+        provider ??= new FakeHealthReportProvider();
+        tracker ??= new FakeStartupTracker();
+
+        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<OtelEvents.Health.IHealthReportProvider>(provider);
+        builder.Services.AddSingleton<OtelEvents.Health.IStartupTracker>(tracker);
+
+        var app = builder.Build();
+        app.MapHealthEndpoints(configure);
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var env = new TestEnv(client, app);
+        _disposables.Add(env);
+        return env;
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────
+
+    private static HealthReport CreateAllCircuitOpenReport() => new(
+        HealthStatus.Unhealthy,
+        CreateAllCircuitOpenDependencies(),
+        BaseTime);
+
+    private static IReadOnlyList<DependencySnapshot> CreateAllCircuitOpenDependencies() =>
+    [
+        CreateSnapshot(DbDependency, HealthState.CircuitOpen, 0.3, 100, 70, 30),
+        CreateSnapshot(CacheDependency, HealthState.CircuitOpen, 0.1, 50, 45, 5),
+    ];
+
+    private sealed class TestEnv(HttpClient client, WebApplication app) : IAsyncDisposable
+    {
+        public HttpClient Client { get; } = client;
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await app.StopAsync();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/tests/OtelEvents.Health.AspNetCore.Tests/OtelEvents.Health.AspNetCore.Tests.csproj
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/OtelEvents.Health.AspNetCore.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>OtelEvents.Health.AspNetCore.Tests</RootNamespace>
+    <NoWarn>$(NoWarn);1591;CA1001;CA1031;CA1062;CA1508;CA1707;CA1806;CA1826;CA1849;CA1859;CA2000;CA2007;CA2234;CA2263</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OtelEvents.Health.AspNetCore\OtelEvents.Health.AspNetCore.csproj" />
+    <ProjectReference Include="..\..\src\OtelEvents.Health\OtelEvents.Health.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/OtelEvents.Health.AspNetCore.Tests/ProbeEndpointIntegrationTests.cs
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/ProbeEndpointIntegrationTests.cs
@@ -1,0 +1,307 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using static OtelEvents.Health.AspNetCore.Tests.TestFixtures;
+
+namespace OtelEvents.Health.AspNetCore.Tests;
+
+public sealed class ProbeEndpointIntegrationTests : IAsyncDisposable
+{
+    // ── Liveness ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Liveness_returns_200_for_healthy()
+    {
+        await using var env = await CreateTestEnv();
+
+        var response = await env.Client.GetAsync("/healthz/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Liveness_returns_503_for_unhealthy()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = CreateUnhealthyReport(),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    [Fact]
+    public async Task Liveness_returns_200_for_degraded()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            HealthReport = CreateDegradedReport(),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Liveness_body_contains_healthy_status()
+    {
+        await using var env = await CreateTestEnv();
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        body.Should().Be("""{"status":"healthy"}""");
+    }
+
+    // ── Readiness ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Readiness_returns_200_for_ready()
+    {
+        await using var env = await CreateTestEnv();
+
+        var response = await env.Client.GetAsync("/healthz/ready");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Readiness_returns_503_for_not_ready()
+    {
+        var provider = new FakeHealthReportProvider
+        {
+            ReadinessReport = CreateNotReadyReport(),
+        };
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/ready");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+    }
+
+    // ── Startup ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task Startup_returns_200_for_starting()
+    {
+        var tracker = new FakeStartupTracker(); // default is Starting
+        await using var env = await CreateTestEnv(tracker: tracker);
+
+        var response = await env.Client.GetAsync("/healthz/startup");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Be("""{"status":"starting"}""");
+    }
+
+    [Fact]
+    public async Task Startup_returns_200_for_ready()
+    {
+        var tracker = new FakeStartupTracker();
+        tracker.MarkReady();
+        await using var env = await CreateTestEnv(tracker: tracker);
+
+        var response = await env.Client.GetAsync("/healthz/startup");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Be("""{"status":"ready"}""");
+    }
+
+    [Fact]
+    public async Task Startup_returns_503_for_failed()
+    {
+        var tracker = new FakeStartupTracker();
+        tracker.MarkFailed();
+        await using var env = await CreateTestEnv(tracker: tracker);
+
+        var response = await env.Client.GetAsync("/healthz/startup");
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Be("""{"status":"failed"}""");
+    }
+
+    // ── Custom Paths ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Custom_paths_are_honored()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.LivenessPath = "/custom/live";
+            opts.ReadinessPath = "/custom/ready";
+            opts.StartupPath = "/custom/startup";
+        });
+
+        var liveness = await env.Client.GetAsync("/custom/live");
+        var readiness = await env.Client.GetAsync("/custom/ready");
+        var startup = await env.Client.GetAsync("/custom/startup");
+
+        liveness.StatusCode.Should().Be(HttpStatusCode.OK);
+        readiness.StatusCode.Should().Be(HttpStatusCode.OK);
+        startup.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Default_paths_return_404_when_custom_paths_are_used()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.LivenessPath = "/custom/live";
+        });
+
+        var response = await env.Client.GetAsync("/healthz/live");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Content Type ──────────────────────────────────────────
+
+    [Fact]
+    public async Task Response_content_type_is_application_json()
+    {
+        await using var env = await CreateTestEnv();
+
+        var response = await env.Client.GetAsync("/healthz/live");
+
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+    }
+
+    // ── Default Detail Level ──────────────────────────────────
+
+    [Fact]
+    public async Task Default_detail_level_is_status_only()
+    {
+        await using var env = await CreateTestEnv();
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        body.Should().NotContain("dependencies");
+        body.Should().NotContain("success_rate");
+    }
+
+    [Fact]
+    public async Task Summary_detail_level_includes_dependencies()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Summary;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+
+        doc.RootElement.GetProperty("dependencies").GetArrayLength().Should().Be(2);
+    }
+
+    // ── Error Handling ────────────────────────────────────────
+
+    [Fact]
+    public async Task Exception_does_not_leak_into_liveness_response()
+    {
+        var provider = new ThrowingHealthReportProvider();
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        body.Should().Be("""{"status":"unhealthy"}""");
+        body.Should().NotContain("Exception");
+        body.Should().NotContain("Simulated");
+        body.Should().NotContain("stack");
+    }
+
+    [Fact]
+    public async Task Exception_does_not_leak_into_readiness_response()
+    {
+        var provider = new ThrowingHealthReportProvider();
+        await using var env = await CreateTestEnv(provider);
+
+        var response = await env.Client.GetAsync("/healthz/ready");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        body.Should().Be("""{"status":"unhealthy"}""");
+        body.Should().NotContain("Exception");
+    }
+
+    // ── snake_case Integration ─────────────────────────────────
+
+    [Fact]
+    public async Task Full_detail_response_uses_snake_case_keys()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Full;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/live");
+        var body = await response.Content.ReadAsStringAsync();
+
+        body.Should().Contain("success_rate");
+        body.Should().Contain("total_signals");
+        body.Should().NotContain("SuccessRate");
+        body.Should().NotContain("TotalSignals");
+    }
+
+    // ── Test Infrastructure ───────────────────────────────────
+
+    private readonly List<IAsyncDisposable> _disposables = [];
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var disposable in _disposables)
+        {
+            await disposable.DisposeAsync();
+        }
+    }
+
+    private async Task<TestEnv> CreateTestEnv(
+        OtelEvents.Health.IHealthReportProvider? provider = null,
+        OtelEvents.Health.IStartupTracker? tracker = null,
+        Action<OtelEventsHealthEndpointOptions>? configure = null)
+    {
+        provider ??= new FakeHealthReportProvider();
+        tracker ??= new FakeStartupTracker();
+
+        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<OtelEvents.Health.IHealthReportProvider>(provider);
+        builder.Services.AddSingleton<OtelEvents.Health.IStartupTracker>(tracker);
+
+        var app = builder.Build();
+        app.MapHealthEndpoints(configure);
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var env = new TestEnv(client, app);
+        _disposables.Add(env);
+        return env;
+    }
+
+    private sealed class TestEnv(HttpClient client, WebApplication app) : IAsyncDisposable
+    {
+        public HttpClient Client { get; } = client;
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await app.StopAsync();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/tests/OtelEvents.Health.AspNetCore.Tests/ProbeResponseWriterTests.cs
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/ProbeResponseWriterTests.cs
@@ -1,0 +1,243 @@
+using System.Text.Json;
+using FluentAssertions;
+using OtelEvents.Health.Contracts;
+
+namespace OtelEvents.Health.AspNetCore.Tests;
+
+public sealed class ProbeResponseWriterTests
+{
+    // ── Liveness — StatusOnly ─────────────────────────────────
+
+    [Fact]
+    public void WriteLiveness_StatusOnly_healthy_returns_minimal_json()
+    {
+        var report = TestFixtures.CreateHealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.StatusOnly);
+
+        json.Should().Be("""{"status":"healthy"}""");
+    }
+
+    [Fact]
+    public void WriteLiveness_StatusOnly_unhealthy_returns_minimal_json()
+    {
+        var report = TestFixtures.CreateUnhealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.StatusOnly);
+
+        json.Should().Be("""{"status":"unhealthy"}""");
+    }
+
+    [Fact]
+    public void WriteLiveness_StatusOnly_degraded_returns_minimal_json()
+    {
+        var report = TestFixtures.CreateDegradedReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.StatusOnly);
+
+        json.Should().Be("""{"status":"degraded"}""");
+    }
+
+    [Fact]
+    public void WriteLiveness_StatusOnly_has_no_dependencies_field()
+    {
+        var report = TestFixtures.CreateHealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.StatusOnly);
+
+        json.Should().NotContain("dependencies");
+    }
+
+    // ── Liveness — Summary ────────────────────────────────────
+
+    [Fact]
+    public void WriteLiveness_Summary_includes_dependency_names_and_states()
+    {
+        var report = TestFixtures.CreateHealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.Summary);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("status").GetString().Should().Be("healthy");
+
+        var deps = root.GetProperty("dependencies");
+        deps.GetArrayLength().Should().Be(2);
+        deps[0].GetProperty("name").GetString().Should().Be("postgres-main");
+        deps[0].GetProperty("state").GetString().Should().Be("healthy");
+        deps[1].GetProperty("name").GetString().Should().Be("redis-cache");
+        deps[1].GetProperty("state").GetString().Should().Be("healthy");
+    }
+
+    [Fact]
+    public void WriteLiveness_Summary_does_not_include_metrics()
+    {
+        var report = TestFixtures.CreateHealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.Summary);
+
+        json.Should().NotContain("success_rate");
+        json.Should().NotContain("total_signals");
+        json.Should().NotContain("failure_count");
+        json.Should().NotContain("success_count");
+    }
+
+    // ── Liveness — Full ───────────────────────────────────────
+
+    [Fact]
+    public void WriteLiveness_Full_includes_metrics()
+    {
+        var report = TestFixtures.CreateHealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.Full);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        var deps = root.GetProperty("dependencies");
+
+        deps[0].GetProperty("name").GetString().Should().Be("postgres-main");
+        deps[0].GetProperty("state").GetString().Should().Be("healthy");
+        deps[0].GetProperty("success_rate").GetDouble().Should().Be(0.99);
+        deps[0].GetProperty("total_signals").GetInt32().Should().Be(100);
+        deps[0].GetProperty("failure_count").GetInt32().Should().Be(1);
+        deps[0].GetProperty("success_count").GetInt32().Should().Be(99);
+    }
+
+    // ── Readiness — StatusOnly ────────────────────────────────
+
+    [Fact]
+    public void WriteReadiness_StatusOnly_ready_returns_minimal_json()
+    {
+        var report = TestFixtures.CreateReadyReport();
+
+        var json = ProbeResponseWriter.WriteReadinessResponse(report, DetailLevel.StatusOnly);
+
+        json.Should().Be("""{"status":"ready"}""");
+    }
+
+    [Fact]
+    public void WriteReadiness_StatusOnly_not_ready_returns_minimal_json()
+    {
+        var report = TestFixtures.CreateNotReadyReport();
+
+        var json = ProbeResponseWriter.WriteReadinessResponse(report, DetailLevel.StatusOnly);
+
+        json.Should().Be("""{"status":"not_ready"}""");
+    }
+
+    // ── Readiness — Summary ───────────────────────────────────
+
+    [Fact]
+    public void WriteReadiness_Summary_includes_startup_and_drain_status()
+    {
+        var report = TestFixtures.CreateReadyReport();
+
+        var json = ProbeResponseWriter.WriteReadinessResponse(report, DetailLevel.Summary);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("status").GetString().Should().Be("ready");
+        root.GetProperty("startup_status").GetString().Should().Be("ready");
+        root.GetProperty("drain_status").GetString().Should().Be("idle");
+        root.GetProperty("dependencies").GetArrayLength().Should().Be(2);
+    }
+
+    // ── Readiness — Full ──────────────────────────────────────
+
+    [Fact]
+    public void WriteReadiness_Full_includes_metrics()
+    {
+        var report = TestFixtures.CreateReadyReport();
+
+        var json = ProbeResponseWriter.WriteReadinessResponse(report, DetailLevel.Full);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("startup_status").GetString().Should().Be("ready");
+        root.GetProperty("drain_status").GetString().Should().Be("idle");
+
+        var deps = root.GetProperty("dependencies");
+        deps[0].GetProperty("success_rate").GetDouble().Should().Be(0.99);
+        deps[0].GetProperty("total_signals").GetInt32().Should().Be(100);
+    }
+
+    // ── Startup ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(StartupStatus.Starting, """{"status":"starting"}""")]
+    [InlineData(StartupStatus.Ready, """{"status":"ready"}""")]
+    [InlineData(StartupStatus.Failed, """{"status":"failed"}""")]
+    public void WriteStartup_returns_correct_json(StartupStatus status, string expected)
+    {
+        var json = ProbeResponseWriter.WriteStartupResponse(status);
+
+        json.Should().Be(expected);
+    }
+
+    // ── snake_case Verification ───────────────────────────────
+
+    [Fact]
+    public void Json_keys_are_snake_case()
+    {
+        var report = TestFixtures.CreateHealthyReport();
+
+        var json = ProbeResponseWriter.WriteLivenessResponse(report, DetailLevel.Full);
+
+        json.Should().Contain("success_rate");
+        json.Should().Contain("total_signals");
+        json.Should().Contain("failure_count");
+        json.Should().Contain("success_count");
+        json.Should().NotContain("SuccessRate");
+        json.Should().NotContain("TotalSignals");
+    }
+
+    [Fact]
+    public void Readiness_json_keys_are_snake_case()
+    {
+        var report = TestFixtures.CreateReadyReport();
+
+        var json = ProbeResponseWriter.WriteReadinessResponse(report, DetailLevel.Summary);
+
+        json.Should().Contain("startup_status");
+        json.Should().Contain("drain_status");
+        json.Should().NotContain("StartupStatus");
+        json.Should().NotContain("DrainStatus");
+    }
+
+    // ── Status Code Mapping ───────────────────────────────────
+
+    [Theory]
+    [InlineData(HealthStatus.Healthy, 200)]
+    [InlineData(HealthStatus.Degraded, 200)]
+    [InlineData(HealthStatus.Unhealthy, 503)]
+    public void GetLivenessStatusCode_returns_expected(HealthStatus status, int expected)
+    {
+        ProbeResponseWriter.GetLivenessStatusCode(status).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(ReadinessStatus.Ready, 200)]
+    [InlineData(ReadinessStatus.NotReady, 503)]
+    public void GetReadinessStatusCode_returns_expected(ReadinessStatus status, int expected)
+    {
+        ProbeResponseWriter.GetReadinessStatusCode(status).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(StartupStatus.Starting, 200)]
+    [InlineData(StartupStatus.Ready, 200)]
+    [InlineData(StartupStatus.Failed, 503)]
+    public void GetStartupStatusCode_returns_expected(StartupStatus status, int expected)
+    {
+        ProbeResponseWriter.GetStartupStatusCode(status).Should().Be(expected);
+    }
+
+    // ── Error Response ────────────────────────────────────────
+
+    [Fact]
+    public void WriteErrorResponse_returns_unhealthy_status()
+    {
+        var json = ProbeResponseWriter.WriteErrorResponse();
+
+        json.Should().Be("""{"status":"unhealthy"}""");
+    }
+}

--- a/tests/OtelEvents.Health.AspNetCore.Tests/TenantHealthEndpointIntegrationTests.cs
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/TenantHealthEndpointIntegrationTests.cs
@@ -1,0 +1,332 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using static OtelEvents.Health.AspNetCore.Tests.TestFixtures;
+
+namespace OtelEvents.Health.AspNetCore.Tests;
+
+/// <summary>
+/// Integration tests for the tenant health endpoint (/healthz/tenants).
+/// Covers detail level gating, JSON shape, and DI scenarios.
+/// </summary>
+public sealed class TenantHealthEndpointIntegrationTests : IAsyncDisposable
+{
+    // ── Detail Level Gating (Security Finding #6) ─────────────
+
+    [Fact]
+    public async Task TenantHealth_returns_403_at_StatusOnly()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.StatusOnly;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("tenant_health_requires_full_detail_level");
+    }
+
+    [Fact]
+    public async Task TenantHealth_returns_403_at_Summary()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Summary;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("tenant_health_requires_full_detail_level");
+    }
+
+    [Fact]
+    public async Task TenantHealth_returns_200_at_Full()
+    {
+        var tenantProvider = new FakeTenantHealthProvider();
+        tenantProvider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Degraded, 0.75, 100, 25, null),
+        });
+
+        await using var env = await CreateTestEnv(
+            tenantProvider: tenantProvider,
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── Response Shape at Full Detail ─────────────────────────
+
+    [Fact]
+    public async Task TenantHealth_Full_response_has_correct_json_shape()
+    {
+        var tenantProvider = new FakeTenantHealthProvider();
+        tenantProvider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Degraded, 0.75, 100, 25, null),
+        });
+
+        await using var env = await CreateTestEnv(
+            tenantProvider: tenantProvider,
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        var components = root.GetProperty("components");
+        components.GetArrayLength().Should().Be(2);
+
+        var firstComponent = components[0];
+        firstComponent.GetProperty("component").GetString().Should().Be("postgres-main");
+        firstComponent.GetProperty("active_tenants").GetInt32().Should().Be(1);
+
+        var tenants = firstComponent.GetProperty("tenants");
+        tenants.GetArrayLength().Should().Be(1);
+        tenants[0].GetProperty("tenant_id").GetString().Should().Be("contoso");
+        tenants[0].GetProperty("status").GetString().Should().Be("degraded");
+        tenants[0].GetProperty("success_rate").GetDouble().Should().Be(0.75);
+        tenants[0].GetProperty("total_signals").GetInt32().Should().Be(100);
+        tenants[0].GetProperty("failure_count").GetInt32().Should().Be(25);
+    }
+
+    [Fact]
+    public async Task TenantHealth_Full_response_uses_snake_case_keys()
+    {
+        var tenantProvider = new FakeTenantHealthProvider();
+        tenantProvider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Healthy, 0.99, 100, 1, null),
+        });
+
+        await using var env = await CreateTestEnv(
+            tenantProvider: tenantProvider,
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+        var body = await response.Content.ReadAsStringAsync();
+
+        body.Should().Contain("active_tenants");
+        body.Should().Contain("tenant_id");
+        body.Should().Contain("success_rate");
+        body.Should().Contain("total_signals");
+        body.Should().Contain("failure_count");
+        body.Should().NotContain("ActiveTenants");
+        body.Should().NotContain("TenantId");
+        body.Should().NotContain("SuccessRate");
+    }
+
+    [Fact]
+    public async Task TenantHealth_response_content_type_is_application_json()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Full;
+        });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+    }
+
+    // ── No Tenant Provider Registered ─────────────────────────
+
+    [Fact]
+    public async Task TenantHealth_no_provider_registered_returns_empty_tenants()
+    {
+        await using var env = await CreateTestEnv(
+            tenantProvider: null, // explicitly no provider
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var doc = JsonDocument.Parse(body);
+        var components = doc.RootElement.GetProperty("components");
+        components.GetArrayLength().Should().Be(2);
+
+        // Both components should have 0 active tenants and empty tenant arrays
+        components[0].GetProperty("active_tenants").GetInt32().Should().Be(0);
+        components[0].GetProperty("tenants").GetArrayLength().Should().Be(0);
+        components[1].GetProperty("active_tenants").GetInt32().Should().Be(0);
+        components[1].GetProperty("tenants").GetArrayLength().Should().Be(0);
+    }
+
+    // ── Multiple Components Different Tenant Counts ───────────
+
+    [Fact]
+    public async Task TenantHealth_multiple_components_with_different_tenant_counts()
+    {
+        var tenantProvider = new FakeTenantHealthProvider();
+        tenantProvider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Healthy, 0.99, 200, 2, null),
+            [new TenantId("fabrikam")] = new(new TenantId("fabrikam"), DbDependency, TenantHealthStatus.Degraded, 0.80, 100, 20, null),
+        });
+        tenantProvider.SetTenants(CacheDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("northwind")] = new(new TenantId("northwind"), CacheDependency, TenantHealthStatus.Healthy, 1.0, 50, 0, null),
+        });
+
+        await using var env = await CreateTestEnv(
+            tenantProvider: tenantProvider,
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var components = doc.RootElement.GetProperty("components");
+
+        components[0].GetProperty("active_tenants").GetInt32().Should().Be(2);
+        components[0].GetProperty("tenants").GetArrayLength().Should().Be(2);
+        components[1].GetProperty("active_tenants").GetInt32().Should().Be(1);
+        components[1].GetProperty("tenants").GetArrayLength().Should().Be(1);
+    }
+
+    // ── Custom Tenant Health Path ─────────────────────────────
+
+    [Fact]
+    public async Task TenantHealth_custom_path_is_honored()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.TenantHealthPath = "/custom/tenants";
+            opts.DefaultDetailLevel = DetailLevel.Full;
+        });
+
+        var response = await env.Client.GetAsync("/custom/tenants");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var defaultPathResponse = await env.Client.GetAsync("/healthz/tenants");
+        defaultPathResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // ── Error Handling ────────────────────────────────────────
+
+    [Fact]
+    public async Task TenantHealth_exception_does_not_leak()
+    {
+        var provider = new ThrowingHealthReportProvider();
+        await using var env = await CreateTestEnv(
+            provider: provider,
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var response = await env.Client.GetAsync("/healthz/tenants");
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        body.Should().Be("""{"status":"unhealthy"}""");
+        body.Should().NotContain("Exception");
+        body.Should().NotContain("Simulated");
+    }
+
+    // ── Thread Safety: Concurrent Reads ───────────────────────
+
+    [Fact]
+    public async Task TenantHealth_concurrent_reads_do_not_throw()
+    {
+        var tenantProvider = new FakeTenantHealthProvider();
+        tenantProvider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Healthy, 0.99, 100, 1, null),
+        });
+
+        await using var env = await CreateTestEnv(
+            tenantProvider: tenantProvider,
+            configure: opts => { opts.DefaultDetailLevel = DetailLevel.Full; });
+
+        var tasks = Enumerable.Range(0, 20)
+            .Select(_ => env.Client.GetAsync("/healthz/tenants"))
+            .ToArray();
+
+        var responses = await Task.WhenAll(tasks);
+
+        responses.Should().OnlyContain(r => r.StatusCode == HttpStatusCode.OK);
+    }
+
+    // ── Existing Endpoints Still Work ─────────────────────────
+
+    [Fact]
+    public async Task Existing_endpoints_still_work_after_tenant_endpoint_added()
+    {
+        await using var env = await CreateTestEnv(configure: opts =>
+        {
+            opts.DefaultDetailLevel = DetailLevel.Full;
+        });
+
+        var liveness = await env.Client.GetAsync("/healthz/live");
+        var readiness = await env.Client.GetAsync("/healthz/ready");
+        var startup = await env.Client.GetAsync("/healthz/startup");
+
+        liveness.StatusCode.Should().Be(HttpStatusCode.OK);
+        readiness.StatusCode.Should().Be(HttpStatusCode.OK);
+        startup.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ── Test Infrastructure ───────────────────────────────────
+
+    private readonly List<IAsyncDisposable> _disposables = [];
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var disposable in _disposables)
+        {
+            await disposable.DisposeAsync();
+        }
+    }
+
+    private async Task<TestEnv> CreateTestEnv(
+        OtelEvents.Health.IHealthReportProvider? provider = null,
+        ITenantHealthProvider? tenantProvider = null,
+        OtelEvents.Health.IStartupTracker? tracker = null,
+        Action<OtelEventsHealthEndpointOptions>? configure = null)
+    {
+        provider ??= new FakeHealthReportProvider();
+        tracker ??= new FakeStartupTracker();
+
+        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+        builder.WebHost.UseTestServer();
+        builder.Services.AddSingleton<OtelEvents.Health.IHealthReportProvider>(provider);
+        builder.Services.AddSingleton<OtelEvents.Health.IStartupTracker>(tracker);
+
+        if (tenantProvider is not null)
+        {
+            builder.Services.AddSingleton(tenantProvider);
+        }
+
+        var app = builder.Build();
+        app.MapHealthEndpoints(configure);
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var env = new TestEnv(client, app);
+        _disposables.Add(env);
+        return env;
+    }
+
+    private sealed class TestEnv(HttpClient client, WebApplication app) : IAsyncDisposable
+    {
+        public HttpClient Client { get; } = client;
+
+        public async ValueTask DisposeAsync()
+        {
+            Client.Dispose();
+            await app.StopAsync();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/tests/OtelEvents.Health.AspNetCore.Tests/TenantHealthResponseWriterTests.cs
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/TenantHealthResponseWriterTests.cs
@@ -1,0 +1,222 @@
+using System.Text.Json;
+using FluentAssertions;
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+using static OtelEvents.Health.AspNetCore.Tests.TestFixtures;
+
+namespace OtelEvents.Health.AspNetCore.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="TenantHealthResponseWriter"/>.
+/// Covers JSON serialization, snake_case keys, detail level gating, and edge cases.
+/// </summary>
+public sealed class TenantHealthResponseWriterTests
+{
+    // ── Tenant Health at Full Detail ───────────────────────────
+
+    [Fact]
+    public void WriteTenantHealth_with_provider_returns_tenant_data()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider();
+        provider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Degraded, 0.75, 100, 25, null),
+        });
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        root.GetProperty("components").GetArrayLength().Should().Be(2);
+        var firstComponent = root.GetProperty("components")[0];
+        firstComponent.GetProperty("component").GetString().Should().Be("postgres-main");
+        firstComponent.GetProperty("active_tenants").GetInt32().Should().Be(1);
+
+        var tenants = firstComponent.GetProperty("tenants");
+        tenants.GetArrayLength().Should().Be(1);
+        tenants[0].GetProperty("tenant_id").GetString().Should().Be("contoso");
+        tenants[0].GetProperty("status").GetString().Should().Be("degraded");
+        tenants[0].GetProperty("success_rate").GetDouble().Should().Be(0.75);
+        tenants[0].GetProperty("total_signals").GetInt32().Should().Be(100);
+        tenants[0].GetProperty("failure_count").GetInt32().Should().Be(25);
+    }
+
+    [Fact]
+    public void WriteTenantHealth_null_provider_returns_empty_tenants()
+    {
+        var report = CreateHealthyReport();
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider: null);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var components = root.GetProperty("components");
+        components.GetArrayLength().Should().Be(2);
+        components[0].GetProperty("active_tenants").GetInt32().Should().Be(0);
+        components[0].GetProperty("tenants").GetArrayLength().Should().Be(0);
+        components[1].GetProperty("active_tenants").GetInt32().Should().Be(0);
+        components[1].GetProperty("tenants").GetArrayLength().Should().Be(0);
+    }
+
+    [Fact]
+    public void WriteTenantHealth_multiple_components_with_different_tenant_counts()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider();
+
+        // postgres-main has 2 tenants
+        provider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Healthy, 0.99, 200, 2, null),
+            [new TenantId("fabrikam")] = new(new TenantId("fabrikam"), DbDependency, TenantHealthStatus.Degraded, 0.80, 100, 20, null),
+        });
+
+        // redis-cache has 3 tenants
+        provider.SetTenants(CacheDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("northwind")] = new(new TenantId("northwind"), CacheDependency, TenantHealthStatus.Healthy, 1.0, 50, 0, null),
+            [new TenantId("adventure-works")] = new(new TenantId("adventure-works"), CacheDependency, TenantHealthStatus.Healthy, 0.95, 75, 4, null),
+            [new TenantId("wide-world")] = new(new TenantId("wide-world"), CacheDependency, TenantHealthStatus.Unavailable, 0.20, 60, 48, null),
+        });
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+        using var doc = JsonDocument.Parse(json);
+        var components = doc.RootElement.GetProperty("components");
+
+        components[0].GetProperty("active_tenants").GetInt32().Should().Be(2);
+        components[0].GetProperty("tenants").GetArrayLength().Should().Be(2);
+
+        components[1].GetProperty("active_tenants").GetInt32().Should().Be(3);
+        components[1].GetProperty("tenants").GetArrayLength().Should().Be(3);
+    }
+
+    // ── snake_case Verification ───────────────────────────────
+
+    [Fact]
+    public void Tenant_json_keys_are_snake_case()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider();
+        provider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Healthy, 0.99, 100, 1, null),
+        });
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+
+        json.Should().Contain("active_tenants");
+        json.Should().Contain("tenant_id");
+        json.Should().Contain("success_rate");
+        json.Should().Contain("total_signals");
+        json.Should().Contain("failure_count");
+        json.Should().NotContain("ActiveTenants");
+        json.Should().NotContain("TenantId");
+        json.Should().NotContain("SuccessRate");
+        json.Should().NotContain("TotalSignals");
+        json.Should().NotContain("FailureCount");
+    }
+
+    // ── Forbidden Response ────────────────────────────────────
+
+    [Fact]
+    public void WriteForbiddenResponse_returns_error_message()
+    {
+        var json = TenantHealthResponseWriter.WriteForbiddenResponse();
+
+        json.Should().Contain("error");
+        json.Should().Contain("tenant_health_requires_full_detail_level");
+    }
+
+    // ── Status String Mapping ─────────────────────────────────
+
+    [Fact]
+    public void Tenant_status_healthy_serializes_as_snake_case()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider();
+        provider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("t1")] = new(new TenantId("t1"), DbDependency, TenantHealthStatus.Healthy, 1.0, 50, 0, null),
+        });
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+        using var doc = JsonDocument.Parse(json);
+        var tenant = doc.RootElement.GetProperty("components")[0].GetProperty("tenants")[0];
+
+        tenant.GetProperty("status").GetString().Should().Be("healthy");
+    }
+
+    [Fact]
+    public void Tenant_status_unavailable_serializes_as_snake_case()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider();
+        provider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("t1")] = new(new TenantId("t1"), DbDependency, TenantHealthStatus.Unavailable, 0.10, 80, 72, null),
+        });
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+        using var doc = JsonDocument.Parse(json);
+        var tenant = doc.RootElement.GetProperty("components")[0].GetProperty("tenants")[0];
+
+        tenant.GetProperty("status").GetString().Should().Be("unavailable");
+    }
+
+    // ── Empty Report (no dependencies) ────────────────────────
+
+    [Fact]
+    public void WriteTenantHealth_empty_report_returns_empty_components()
+    {
+        var report = CreateEmptyReport(HealthStatus.Healthy);
+        var provider = new FakeTenantHealthProvider();
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+        using var doc = JsonDocument.Parse(json);
+
+        doc.RootElement.GetProperty("components").GetArrayLength().Should().Be(0);
+    }
+
+    // ── Provider returns null for unknown component ───────────
+
+    [Fact]
+    public void WriteTenantHealth_provider_returns_null_for_untracked_component()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider(); // no tenants set
+
+        var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+        using var doc = JsonDocument.Parse(json);
+        var firstComponent = doc.RootElement.GetProperty("components")[0];
+
+        firstComponent.GetProperty("active_tenants").GetInt32().Should().Be(0);
+        firstComponent.GetProperty("tenants").GetArrayLength().Should().Be(0);
+    }
+
+    // ── Thread Safety ─────────────────────────────────────────
+
+    [Fact]
+    public async Task WriteTenantHealth_concurrent_reads_do_not_throw()
+    {
+        var report = CreateHealthyReport();
+        var provider = new FakeTenantHealthProvider();
+        provider.SetTenants(DbDependency, new Dictionary<TenantId, TenantHealthAssessment>
+        {
+            [new TenantId("contoso")] = new(new TenantId("contoso"), DbDependency, TenantHealthStatus.Healthy, 0.99, 100, 1, null),
+        });
+
+        var tasks = Enumerable.Range(0, 20)
+            .Select(_ => Task.Run(() =>
+            {
+                var json = TenantHealthResponseWriter.WriteTenantHealthResponse(report, provider);
+                using var doc = JsonDocument.Parse(json);
+                return doc.RootElement.GetProperty("components").GetArrayLength();
+            }))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        results.Should().OnlyContain(count => count == 2);
+    }
+}

--- a/tests/OtelEvents.Health.AspNetCore.Tests/TestFixtures.cs
+++ b/tests/OtelEvents.Health.AspNetCore.Tests/TestFixtures.cs
@@ -1,0 +1,148 @@
+using OtelEvents.Health;
+using OtelEvents.Health.Contracts;
+
+namespace OtelEvents.Health.AspNetCore.Tests;
+
+/// <summary>
+/// Shared test fixtures for OtelEvents.Health.AspNetCore tests.
+/// </summary>
+internal static class TestFixtures
+{
+    internal static readonly DateTimeOffset BaseTime =
+        new(2024, 1, 15, 12, 0, 0, TimeSpan.Zero);
+
+    internal static readonly DependencyId DbDependency = new("postgres-main");
+    internal static readonly DependencyId CacheDependency = new("redis-cache");
+
+    // ── Health Reports ────────────────────────────────────────
+
+    internal static HealthReport CreateHealthyReport() => new(
+        HealthStatus.Healthy,
+        CreateHealthyDependencies(),
+        BaseTime);
+
+    internal static HealthReport CreateDegradedReport() => new(
+        HealthStatus.Degraded,
+        CreateDegradedDependencies(),
+        BaseTime);
+
+    internal static HealthReport CreateUnhealthyReport() => new(
+        HealthStatus.Unhealthy,
+        CreateUnhealthyDependencies(),
+        BaseTime);
+
+    internal static HealthReport CreateEmptyReport(HealthStatus status) => new(
+        status,
+        Array.Empty<DependencySnapshot>(),
+        BaseTime);
+
+    // ── Readiness Reports ─────────────────────────────────────
+
+    internal static ReadinessReport CreateReadyReport() => new(
+        ReadinessStatus.Ready,
+        CreateHealthyDependencies(),
+        BaseTime,
+        StartupStatus.Ready,
+        DrainStatus.Idle);
+
+    internal static ReadinessReport CreateNotReadyReport() => new(
+        ReadinessStatus.NotReady,
+        CreateUnhealthyDependencies(),
+        BaseTime,
+        StartupStatus.Ready,
+        DrainStatus.Draining);
+
+    // ── Dependency Snapshots ──────────────────────────────────
+
+    internal static IReadOnlyList<DependencySnapshot> CreateHealthyDependencies() =>
+    [
+        CreateSnapshot(DbDependency, HealthState.Healthy, 0.99, 100, 1, 99),
+        CreateSnapshot(CacheDependency, HealthState.Healthy, 1.0, 50, 0, 50),
+    ];
+
+    internal static IReadOnlyList<DependencySnapshot> CreateDegradedDependencies() =>
+    [
+        CreateSnapshot(DbDependency, HealthState.Degraded, 0.85, 100, 15, 85),
+        CreateSnapshot(CacheDependency, HealthState.Healthy, 1.0, 50, 0, 50),
+    ];
+
+    internal static IReadOnlyList<DependencySnapshot> CreateUnhealthyDependencies() =>
+    [
+        CreateSnapshot(DbDependency, HealthState.CircuitOpen, 0.3, 100, 70, 30),
+        CreateSnapshot(CacheDependency, HealthState.Healthy, 1.0, 50, 0, 50),
+    ];
+
+    internal static DependencySnapshot CreateSnapshot(
+        DependencyId id,
+        HealthState state,
+        double successRate,
+        int totalSignals,
+        int failureCount,
+        int successCount) => new(
+            id,
+            state,
+            new HealthAssessment(
+                id,
+                successRate,
+                totalSignals,
+                failureCount,
+                successCount,
+                TimeSpan.FromMinutes(5),
+                BaseTime,
+                state,
+                state,
+                null),
+            BaseTime,
+            state == HealthState.Healthy ? 0 : failureCount);
+
+    // ── Fake Startup Tracker ─────────────────────────────────
+
+    internal sealed class FakeStartupTracker : OtelEvents.Health.IStartupTracker
+    {
+        private volatile StartupStatus _status = StartupStatus.Starting;
+
+        public StartupStatus Status => _status;
+        public void MarkReady() => _status = StartupStatus.Ready;
+        public void MarkFailed(string? reason = null) => _status = StartupStatus.Failed;
+    }
+
+    // ── Fake Provider ─────────────────────────────────────────
+
+    internal sealed class FakeHealthReportProvider : IHealthReportProvider
+    {
+        public HealthReport HealthReport { get; set; } = CreateHealthyReport();
+        public ReadinessReport ReadinessReport { get; set; } = CreateReadyReport();
+
+        public HealthReport GetHealthReport() => HealthReport;
+        public ReadinessReport GetReadinessReport() => ReadinessReport;
+    }
+
+    internal sealed class ThrowingHealthReportProvider : IHealthReportProvider
+    {
+        public HealthReport GetHealthReport() =>
+            throw new InvalidOperationException("Simulated failure");
+
+        public ReadinessReport GetReadinessReport() =>
+            throw new InvalidOperationException("Simulated failure");
+    }
+
+    // ── Fake Tenant Health Provider ───────────────────────────
+
+    internal sealed class FakeTenantHealthProvider : ITenantHealthProvider
+    {
+        private readonly Dictionary<DependencyId, Dictionary<TenantId, TenantHealthAssessment>> _data = [];
+
+        public void SetTenants(
+            DependencyId component,
+            Dictionary<TenantId, TenantHealthAssessment> tenants)
+        {
+            _data[component] = tenants;
+        }
+
+        public IReadOnlyDictionary<TenantId, TenantHealthAssessment>? GetAllTenantHealth(DependencyId component) =>
+            _data.TryGetValue(component, out var tenants) ? tenants : null;
+
+        public int ActiveTenantCount(DependencyId component) =>
+            _data.TryGetValue(component, out var tenants) ? tenants.Count : 0;
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `OtelEvents.Health.AspNetCore` package — ASP.NET Core K8s health probe endpoints copied from HealthBoss.AspNetCore with namespace renames.

Closes #57

## What's included

### Source files (6)
| File | Description |
|------|-------------|
| `OtelEventsHealthEndpointExtensions.cs` | `MapHealthEndpoints()` extension method for `IEndpointRouteBuilder` |
| `OtelEventsHealthEndpointOptions.cs` | Configuration: paths, default detail level |
| `ProbeEndpointHandler.cs` | Liveness/readiness/startup HTTP request handlers |
| `ProbeResponseWriter.cs` | JSON serialization with snake_case keys |
| `TenantHealthEndpointHandler.cs` | Per-tenant health with detail-level gating (403 if not Full) |
| `TenantHealthResponseWriter.cs` | Tenant health response serialization |

### Test files (5) — 74 tests total
| File | Tests | Type |
|------|-------|------|
| `ProbeEndpointIntegrationTests.cs` | 20 | Integration |
| `ProbeResponseWriterTests.cs` | 22 | Unit |
| `TenantHealthEndpointIntegrationTests.cs` | 16 | Integration |
| `TenantHealthResponseWriterTests.cs` | 11 | Unit |
| `EdgeCases/ProbeEndpointEdgeCaseTests.cs` | 10 | Edge cases |

### NOT copied (removed HTTP tracking)
- InboundHealthMiddleware, HealthBossDelegatingHandler
- InboundTrackingOptions, OutboundTrackingOptions
- HttpClientBuilderExtensions, InboundTrackingExtensions

## Consumer API
```csharp
app.MapHealthEndpoints();
// or with options
app.MapHealthEndpoints(opts => opts.DefaultDetailLevel = DetailLevel.Summary);
```

## Namespace renames
- `HealthBoss.AspNetCore` → `OtelEvents.Health.AspNetCore`
- `HealthBoss.Core` → `OtelEvents.Health`
- `MapHealthBossEndpoints` → `MapHealthEndpoints`
- `HealthBossEndpointOptions` → `OtelEventsHealthEndpointOptions`

## Verification
- ✅ `dotnet build OtelEvents.slnx` — 0 warnings, 0 errors
- ✅ `dotnet test` — 74/74 tests passing
- ✅ Project reference to `OtelEvents.Health`, framework reference to `Microsoft.AspNetCore.App`
- ✅ No external NuGet dependencies
- ✅ `InternalsVisibleTo` for test project