### PR TITLE
feat(health): HealthSignalBridge — auto-subscribe events to health signals (#56)

### DIFF
--- a/src/OtelEvents.Health/ComponentBuilder.cs
+++ b/src/OtelEvents.Health/ComponentBuilder.cs
@@ -16,6 +16,7 @@ public sealed class ComponentBuilder
     private double _healthyAbove = 0.9;
     private double _degradedAbove = 0.5;
     private int _minimumSignals = 5;
+    private TimeSpan _cooldown = TimeSpan.FromSeconds(30);
     private ResponseTimePolicy? _responseTimePolicy;
 
     /// <summary>
@@ -69,6 +70,19 @@ public sealed class ComponentBuilder
     }
 
     /// <summary>
+    /// Sets the cooldown period before a state transition is committed.
+    /// The component must remain in the candidate state for this duration before transitioning.
+    /// Default: 30 seconds.
+    /// </summary>
+    /// <param name="cooldown">The cooldown duration.</param>
+    /// <returns>This builder for chaining.</returns>
+    public ComponentBuilder Cooldown(TimeSpan cooldown)
+    {
+        _cooldown = cooldown;
+        return this;
+    }
+
+    /// <summary>
     /// Configures an optional response-time (latency) policy for this component.
     /// When configured, the worst-of-both-dimensions determines the final health state.
     /// </summary>
@@ -94,7 +108,7 @@ public sealed class ComponentBuilder
         DegradedThreshold: _healthyAbove,
         CircuitOpenThreshold: _degradedAbove,
         MinSignalsForEvaluation: _minimumSignals,
-        CooldownBeforeTransition: TimeSpan.FromSeconds(30),
+        CooldownBeforeTransition: _cooldown,
         RecoveryProbeInterval: TimeSpan.FromSeconds(10),
         Jitter: new JitterConfig(TimeSpan.Zero, TimeSpan.Zero),
         ResponseTime: _responseTimePolicy);

--- a/src/OtelEvents.Health/Components/TimerBudgetValidator.cs
+++ b/src/OtelEvents.Health/Components/TimerBudgetValidator.cs
@@ -79,7 +79,7 @@ internal sealed class TimerBudgetValidator : ITimerBudgetValidator
                          $"{options.DrainTimeout.TotalSeconds:F0}s drain) exceeds liveness failure window " +
                          $"({options.LivenessFailureWindow.TotalSeconds:F0}s). " +
                          "Kubernetes may kill the pod before drain completes.",
-                ConfigPath: $"HealthBoss:Components:{depName}:RecoveryProbeInterval",
+                ConfigPath: $"OtelEvents.Health:Components:{depName}:RecoveryProbeInterval",
                 IsCritical: false));
         }
     }
@@ -111,7 +111,7 @@ internal sealed class TimerBudgetValidator : ITimerBudgetValidator
                          $"{options.ForceShutdownTimeout.TotalSeconds:F0}s force) exceeds " +
                          $"terminationGracePeriod ({options.TerminationGracePeriod.TotalSeconds:F0}s). " +
                          "SIGKILL will arrive before graceful shutdown completes.",
-                ConfigPath: $"HealthBoss:Components:{depName}:DrainTimeout",
+                ConfigPath: $"OtelEvents.Health:Components:{depName}:DrainTimeout",
                 IsCritical: false));
         }
     }
@@ -137,7 +137,7 @@ internal sealed class TimerBudgetValidator : ITimerBudgetValidator
                 Message: $"CooldownBeforeTransition ({policy.CooldownBeforeTransition.TotalSeconds:F0}s) " +
                          $"is less than RecoveryProbeInterval ({policy.RecoveryProbeInterval.TotalSeconds:F0}s). " +
                          "Transition may fire before the next recovery probe completes.",
-                ConfigPath: $"HealthBoss:Components:{depName}:CooldownBeforeTransition",
+                ConfigPath: $"OtelEvents.Health:Components:{depName}:CooldownBeforeTransition",
                 IsCritical: false));
         }
     }
@@ -166,7 +166,7 @@ internal sealed class TimerBudgetValidator : ITimerBudgetValidator
                          $"of CooldownBeforeTransition ({policy.CooldownBeforeTransition.TotalSeconds:F0}s / 2 = " +
                          $"{halfCooldown.TotalSeconds:F1}s). " +
                          "Jitter may dominate the cooldown window.",
-                ConfigPath: $"HealthBoss:Components:{depName}:Jitter",
+                ConfigPath: $"OtelEvents.Health:Components:{depName}:Jitter",
                 IsCritical: false));
         }
     }

--- a/src/OtelEvents.Health/HealthSignalBridge.cs
+++ b/src/OtelEvents.Health/HealthSignalBridge.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using OtelEvents.Health.Contracts;
 using OtelEvents.Schema.Models;
 using OtelEvents.Subscriptions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace OtelEvents.Health;
 
@@ -19,19 +20,22 @@ namespace OtelEvents.Health;
 /// </para>
 /// </summary>
 /// <remarks>
-/// The bridge uses late binding for <see cref="ISignalRecorder"/> to support DI timing:
-/// subscription lambdas are registered at configuration time, but <see cref="ISignalRecorder"/>
-/// is only available after the service provider is built. Call <see cref="Bind"/> to set
-/// the recorder. Events received before binding are silently dropped.
+/// The bridge lazily resolves <see cref="ISignalRecorder"/> from the DI container
+/// on the first <see cref="HandleSignal"/> call. This avoids timing issues where
+/// subscriptions are registered at configuration time but the recorder is only
+/// available after the service provider is built. Call <see cref="Initialize"/>
+/// to provide the <see cref="IServiceProvider"/> after the container is built.
 /// </remarks>
 internal sealed class HealthSignalBridge
 {
     private readonly IReadOnlyList<ComponentDefinition> _components;
+    private IServiceProvider? _serviceProvider;
     private volatile ISignalRecorder? _recorder;
 
     /// <summary>
-    /// Initializes a new instance for late binding via <see cref="Bind"/>.
-    /// Used in production DI where <see cref="ISignalRecorder"/> is not yet available.
+    /// Initializes a new instance for deferred initialization via <see cref="Initialize"/>.
+    /// Used in production DI where <see cref="IServiceProvider"/> is not yet available
+    /// at subscription registration time.
     /// </summary>
     /// <param name="components">Component definitions from parsed YAML.</param>
     internal HealthSignalBridge(IReadOnlyList<ComponentDefinition> components)
@@ -46,21 +50,22 @@ internal sealed class HealthSignalBridge
     /// <param name="components">Component definitions from parsed YAML.</param>
     /// <param name="recorder">The signal recorder to use immediately.</param>
     internal HealthSignalBridge(IReadOnlyList<ComponentDefinition> components, ISignalRecorder recorder)
-        : this(components)
     {
+        ArgumentNullException.ThrowIfNull(components);
         ArgumentNullException.ThrowIfNull(recorder);
+        _components = components;
         _recorder = recorder;
     }
 
     /// <summary>
-    /// Binds the <see cref="ISignalRecorder"/> for signal recording.
-    /// Called after the DI container is built.
+    /// Injects the <see cref="IServiceProvider"/> for lazy <see cref="ISignalRecorder"/>
+    /// resolution. Called after the DI container is built (typically from a hosted service).
     /// </summary>
-    /// <param name="recorder">The signal recorder resolved from DI.</param>
-    internal void Bind(ISignalRecorder recorder)
+    /// <param name="serviceProvider">The root service provider.</param>
+    internal void Initialize(IServiceProvider serviceProvider)
     {
-        ArgumentNullException.ThrowIfNull(recorder);
-        _recorder = recorder;
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        _serviceProvider = serviceProvider;
     }
 
     /// <summary>
@@ -99,10 +104,10 @@ internal sealed class HealthSignalBridge
     /// <param name="ctx">The event context snapshot.</param>
     internal void HandleSignal(DependencyId depId, SignalMapping mapping, OtelEventContext ctx)
     {
-        var recorder = _recorder;
+        var recorder = _recorder ??= _serviceProvider?.GetRequiredService<ISignalRecorder>();
         if (recorder is null)
         {
-            return; // Not yet bound — silently drop
+            return; // No recorder and no service provider — silently drop
         }
 
         if (!MatchesFilters(mapping.Match, ctx))

--- a/src/OtelEvents.Health/HealthSignalBridge.cs
+++ b/src/OtelEvents.Health/HealthSignalBridge.cs
@@ -1,0 +1,236 @@
+// <copyright file="HealthSignalBridge.cs" company="OtelEvents">
+// Copyright (c) OtelEvents. All rights reserved.
+// </copyright>
+
+using System.Globalization;
+using OtelEvents.Health.Contracts;
+using OtelEvents.Schema.Models;
+using OtelEvents.Subscriptions;
+
+namespace OtelEvents.Health;
+
+/// <summary>
+/// Auto-subscribe bridge between otel-events subscriptions and the Health state machine.
+/// <para>
+/// At startup, reads <see cref="ComponentDefinition"/> instances (parsed from YAML)
+/// and registers otel-events subscriptions for each signal mapping. When an event
+/// fires and matches the component's filters, the bridge classifies the outcome,
+/// extracts latency, and records a <see cref="HealthSignal"/> via <see cref="ISignalRecorder"/>.
+/// </para>
+/// </summary>
+/// <remarks>
+/// The bridge uses late binding for <see cref="ISignalRecorder"/> to support DI timing:
+/// subscription lambdas are registered at configuration time, but <see cref="ISignalRecorder"/>
+/// is only available after the service provider is built. Call <see cref="Bind"/> to set
+/// the recorder. Events received before binding are silently dropped.
+/// </remarks>
+internal sealed class HealthSignalBridge
+{
+    private readonly IReadOnlyList<ComponentDefinition> _components;
+    private volatile ISignalRecorder? _recorder;
+
+    /// <summary>
+    /// Initializes a new instance for late binding via <see cref="Bind"/>.
+    /// Used in production DI where <see cref="ISignalRecorder"/> is not yet available.
+    /// </summary>
+    /// <param name="components">Component definitions from parsed YAML.</param>
+    internal HealthSignalBridge(IReadOnlyList<ComponentDefinition> components)
+    {
+        ArgumentNullException.ThrowIfNull(components);
+        _components = components;
+    }
+
+    /// <summary>
+    /// Initializes a new instance with a pre-bound recorder. Used for unit testing.
+    /// </summary>
+    /// <param name="components">Component definitions from parsed YAML.</param>
+    /// <param name="recorder">The signal recorder to use immediately.</param>
+    internal HealthSignalBridge(IReadOnlyList<ComponentDefinition> components, ISignalRecorder recorder)
+        : this(components)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        _recorder = recorder;
+    }
+
+    /// <summary>
+    /// Binds the <see cref="ISignalRecorder"/> for signal recording.
+    /// Called after the DI container is built.
+    /// </summary>
+    /// <param name="recorder">The signal recorder resolved from DI.</param>
+    internal void Bind(ISignalRecorder recorder)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        _recorder = recorder;
+    }
+
+    /// <summary>
+    /// Registers otel-events subscriptions for all component signal mappings.
+    /// Each signal mapping becomes a subscription that routes matching events
+    /// to <see cref="HandleSignal"/> for classification and recording.
+    /// </summary>
+    /// <param name="builder">The subscription builder to register handlers with.</param>
+    internal void RegisterSubscriptions(OtelEventsSubscriptionBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        foreach (var component in _components)
+        {
+            var depId = new DependencyId(component.Name);
+
+            foreach (var signal in component.Signals)
+            {
+                var mapping = signal; // capture for closure
+                builder.On(signal.Event, (ctx, ct) =>
+                {
+                    HandleSignal(depId, mapping, ctx);
+                    return Task.CompletedTask;
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Processes a single event against a signal mapping.
+    /// Checks match filters, classifies outcome, extracts latency,
+    /// and records the health signal if all criteria are met.
+    /// </summary>
+    /// <param name="depId">The dependency identifier for the owning component.</param>
+    /// <param name="mapping">The signal mapping that triggered this handler.</param>
+    /// <param name="ctx">The event context snapshot.</param>
+    internal void HandleSignal(DependencyId depId, SignalMapping mapping, OtelEventContext ctx)
+    {
+        var recorder = _recorder;
+        if (recorder is null)
+        {
+            return; // Not yet bound — silently drop
+        }
+
+        if (!MatchesFilters(mapping.Match, ctx))
+        {
+            return;
+        }
+
+        var outcome = ClassifyOutcome(ctx.EventName);
+        if (outcome is null)
+        {
+            return; // Unclassifiable (e.g., *.started) — skip
+        }
+
+        var latency = ExtractLatency(ctx);
+
+        recorder.RecordSignal(depId, new HealthSignal(
+            ctx.Timestamp,
+            depId,
+            outcome.Value,
+            latency));
+    }
+
+    /// <summary>
+    /// Classifies an event name suffix into a <see cref="SignalOutcome"/>.
+    /// Returns <c>null</c> for unrecognized or skippable suffixes (e.g., <c>*.started</c>).
+    /// </summary>
+    /// <param name="eventName">The full event name (e.g., "http.request.failed").</param>
+    /// <returns>The classified outcome, or <c>null</c> if the event should be skipped.</returns>
+    internal static SignalOutcome? ClassifyOutcome(string eventName)
+    {
+        if (eventName.EndsWith(".failed", StringComparison.OrdinalIgnoreCase))
+        {
+            return SignalOutcome.Failure;
+        }
+
+        if (eventName.EndsWith(".throttled", StringComparison.OrdinalIgnoreCase))
+        {
+            return SignalOutcome.Failure;
+        }
+
+        if (eventName.EndsWith(".completed", StringComparison.OrdinalIgnoreCase))
+        {
+            return SignalOutcome.Success;
+        }
+
+        if (eventName.EndsWith(".executed", StringComparison.OrdinalIgnoreCase))
+        {
+            return SignalOutcome.Success;
+        }
+
+        // *.started is a timing marker — skip, don't record
+        // Unknown suffixes are also skipped to avoid false signals
+        return null;
+    }
+
+    /// <summary>
+    /// Checks whether all match filters in the signal mapping are satisfied
+    /// by the event context attributes. All filters must match (AND logic).
+    /// </summary>
+    /// <param name="match">The match filters from the signal mapping.</param>
+    /// <param name="ctx">The event context to check against.</param>
+    /// <returns><c>true</c> if all filters match (or no filters defined); <c>false</c> otherwise.</returns>
+    internal static bool MatchesFilters(
+        IReadOnlyDictionary<string, string> match,
+        OtelEventContext ctx)
+    {
+        if (match.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (var (key, pattern) in match)
+        {
+            var value = ctx.GetAttribute<string>(key);
+            if (value is null)
+            {
+                return false;
+            }
+
+            if (!MatchesPattern(value, pattern))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Matches a value against a pattern. Supports exact match and trailing <c>*</c> wildcard.
+    /// </summary>
+    /// <param name="value">The actual attribute value from the event.</param>
+    /// <param name="pattern">The pattern from the signal mapping (e.g., "/api/orders/*").</param>
+    /// <returns><c>true</c> if the value matches the pattern.</returns>
+    internal static bool MatchesPattern(string value, string pattern)
+    {
+        if (pattern.EndsWith('*'))
+        {
+            var prefix = pattern[..^1];
+            return value.StartsWith(prefix, StringComparison.Ordinal);
+        }
+
+        return string.Equals(value, pattern, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Extracts latency from the event context's <c>durationMs</c> attribute.
+    /// Supports <see cref="double"/>, <see cref="long"/>, <see cref="int"/>,
+    /// <see cref="float"/>, and parseable <see cref="string"/> values.
+    /// </summary>
+    /// <param name="ctx">The event context to extract latency from.</param>
+    /// <returns>The latency as <see cref="TimeSpan"/>, or <c>null</c> if not present or unparseable.</returns>
+    internal static TimeSpan? ExtractLatency(OtelEventContext ctx)
+    {
+        if (!ctx.Attributes.TryGetValue("durationMs", out var val))
+        {
+            return null;
+        }
+
+        return val switch
+        {
+            double d => TimeSpan.FromMilliseconds(d),
+            long l => TimeSpan.FromMilliseconds(l),
+            int i => TimeSpan.FromMilliseconds(i),
+            float f => TimeSpan.FromMilliseconds(f),
+            string s when double.TryParse(s, CultureInfo.InvariantCulture, out var parsed)
+                => TimeSpan.FromMilliseconds(parsed),
+            _ => null,
+        };
+    }
+}

--- a/src/OtelEvents.Health/OtelEvents.Health.csproj
+++ b/src/OtelEvents.Health/OtelEvents.Health.csproj
@@ -15,6 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OtelEvents.Schema\OtelEvents.Schema.csproj" />
+    <ProjectReference Include="..\OtelEvents.Subscriptions\OtelEvents.Subscriptions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="OtelEvents.Health.Tests" />
   </ItemGroup>
 

--- a/src/OtelEvents.Health/OtelEventsHealthExtensions.cs
+++ b/src/OtelEvents.Health/OtelEventsHealthExtensions.cs
@@ -8,6 +8,7 @@ using OtelEvents.Schema.Models;
 using OtelEvents.Schema.Parsing;
 using OtelEvents.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -249,6 +250,11 @@ public static class OtelEventsHealthExtensions
                         builder.MinimumSignals(comp.MinimumSignals);
                     }
 
+                    if (comp.CooldownSeconds > 0)
+                    {
+                        builder.Cooldown(TimeSpan.FromSeconds(comp.CooldownSeconds));
+                    }
+
                     if (comp.ResponseTime is not null)
                     {
                         builder.WithResponseTime(rt =>
@@ -266,7 +272,10 @@ public static class OtelEventsHealthExtensions
             }
         });
 
-        // 2. Create bridge and register subscriptions for components with signals
+        // 2. Create bridge and register subscriptions for components with signals.
+        // The bridge is created at config time; it receives IServiceProvider later
+        // via Initialize() (called from a hosted service), then lazily resolves
+        // ISignalRecorder on the first HandleSignal call.
         var signalComponents = components.Where(c => c.Signals.Count > 0).ToList();
         if (signalComponents.Count > 0)
         {
@@ -278,17 +287,30 @@ public static class OtelEventsHealthExtensions
                 bridge.RegisterSubscriptions(subs);
             });
 
-            // 3. Override ISignalRecorder registration to also bind the bridge.
-            // DI uses the last registration for GetRequiredService<T>(),
-            // so this effectively decorates the original with bridge binding.
-            services.AddSingleton<ISignalRecorder>(sp =>
+            // Inject IServiceProvider into the bridge when the host resolves
+            // hosted services at startup. This runs before the subscription
+            // dispatcher begins dispatching events, guaranteeing the bridge
+            // can lazily resolve ISignalRecorder on first HandleSignal.
+            services.AddSingleton<IHostedService>(sp =>
             {
-                var recorder = (ISignalRecorder)sp.GetRequiredService<IHealthOrchestrator>();
-                bridge.Bind(recorder);
-                return recorder;
+                bridge.Initialize(sp);
+                return NullHostedService.Instance;
             });
         }
 
         return services;
+    }
+
+    /// <summary>
+    /// No-op <see cref="IHostedService"/> used as a sentinel return value for
+    /// DI factory registrations that perform side effects during singleton resolution.
+    /// </summary>
+    private sealed class NullHostedService : IHostedService
+    {
+        public static readonly NullHostedService Instance = new();
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/src/OtelEvents.Health/OtelEventsHealthExtensions.cs
+++ b/src/OtelEvents.Health/OtelEventsHealthExtensions.cs
@@ -4,6 +4,9 @@
 
 using OtelEvents.Health.Components;
 using OtelEvents.Health.Contracts;
+using OtelEvents.Schema.Models;
+using OtelEvents.Schema.Parsing;
+using OtelEvents.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -166,6 +169,125 @@ public static class OtelEventsHealthExtensions
             sp.GetRequiredService<EventSinkDispatcher>());
         services.AddSingleton<IHealthEventSink>(sp =>
             sp.GetRequiredService<EventSinkDispatcher>());
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds the HealthBoss health intelligence layer with YAML-based auto-subscription bridge.
+    /// Parses the schema file, registers health components, and sets up otel-events
+    /// subscriptions that automatically feed health signals to the state machine.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="schemaPath">Path to the YAML schema file containing component definitions.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the schema file cannot be parsed.</exception>
+    public static IServiceCollection AddOtelEventsHealth(
+        this IServiceCollection services,
+        string schemaPath)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentException.ThrowIfNullOrEmpty(schemaPath);
+
+        var parser = new SchemaParser();
+        var result = parser.ParseFile(schemaPath);
+
+        if (!result.IsSuccess)
+        {
+            var errors = string.Join("; ", result.Errors.Select(e => e.Message));
+            throw new InvalidOperationException(
+                $"Failed to parse health schema '{schemaPath}': {errors}");
+        }
+
+        return services.AddOtelEventsHealth(result.Document!.Components);
+    }
+
+    /// <summary>
+    /// Adds the HealthBoss health intelligence layer with auto-subscription bridge
+    /// using pre-parsed component definitions.
+    /// Registers health components from the definitions and sets up otel-events
+    /// subscriptions that automatically feed health signals to the state machine.
+    /// <para>
+    /// This overload internally calls <see cref="AddOtelEventsHealth(IServiceCollection, Action{HealthBossOptions})"/>
+    /// and <see cref="OtelEventsSubscriptionExtensions.AddOtelEventsSubscriptions"/> — do not call them separately.
+    /// </para>
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="components">Component definitions parsed from YAML.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddOtelEventsHealth(
+        this IServiceCollection services,
+        IReadOnlyList<ComponentDefinition> components)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(components);
+
+        // 1. Register core health system with component configurations from YAML
+        services.AddOtelEventsHealth(opts =>
+        {
+            foreach (var comp in components)
+            {
+                opts.AddComponent(comp.Name, builder =>
+                {
+                    if (comp.WindowSeconds > 0)
+                    {
+                        builder.Window(TimeSpan.FromSeconds(comp.WindowSeconds));
+                    }
+
+                    if (comp.HealthyAbove > 0)
+                    {
+                        builder.HealthyAbove(comp.HealthyAbove);
+                    }
+
+                    if (comp.DegradedAbove > 0)
+                    {
+                        builder.DegradedAbove(comp.DegradedAbove);
+                    }
+
+                    if (comp.MinimumSignals > 0)
+                    {
+                        builder.MinimumSignals(comp.MinimumSignals);
+                    }
+
+                    if (comp.ResponseTime is not null)
+                    {
+                        builder.WithResponseTime(rt =>
+                        {
+                            rt.Percentile(comp.ResponseTime.Percentile);
+                            rt.DegradedAfter(TimeSpan.FromMilliseconds(comp.ResponseTime.DegradedAfterMs));
+
+                            if (comp.ResponseTime.UnhealthyAfterMs > 0)
+                            {
+                                rt.UnhealthyAfter(TimeSpan.FromMilliseconds(comp.ResponseTime.UnhealthyAfterMs));
+                            }
+                        });
+                    }
+                });
+            }
+        });
+
+        // 2. Create bridge and register subscriptions for components with signals
+        var signalComponents = components.Where(c => c.Signals.Count > 0).ToList();
+        if (signalComponents.Count > 0)
+        {
+            var bridge = new HealthSignalBridge(signalComponents);
+            services.AddSingleton(bridge);
+
+            services.AddOtelEventsSubscriptions(subs =>
+            {
+                bridge.RegisterSubscriptions(subs);
+            });
+
+            // 3. Override ISignalRecorder registration to also bind the bridge.
+            // DI uses the last registration for GetRequiredService<T>(),
+            // so this effectively decorates the original with bridge binding.
+            services.AddSingleton<ISignalRecorder>(sp =>
+            {
+                var recorder = (ISignalRecorder)sp.GetRequiredService<IHealthOrchestrator>();
+                bridge.Bind(recorder);
+                return recorder;
+            });
+        }
 
         return services;
     }

--- a/src/OtelEvents.Schema/Parsing/SchemaParser.cs
+++ b/src/OtelEvents.Schema/Parsing/SchemaParser.cs
@@ -613,7 +613,7 @@ public sealed class SchemaParser
 
     /// <summary>
     /// Parses a duration string like "300s" or "30s" into seconds.
-    /// Returns 0 if the input is null or unparseable.
+    /// Returns 0 if the input is null, or -1 if the value is present but unparseable.
     /// </summary>
     private static double ParseDurationToSeconds(string? value)
     {
@@ -622,22 +622,22 @@ public sealed class SchemaParser
         if (value.EndsWith("ms", StringComparison.OrdinalIgnoreCase))
         {
             return double.TryParse(value.AsSpan(0, value.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var ms)
-                ? ms / 1000.0 : 0;
+                ? ms / 1000.0 : -1;
         }
 
         if (value.EndsWith('s'))
         {
             return double.TryParse(value.AsSpan(0, value.Length - 1), NumberStyles.Float, CultureInfo.InvariantCulture, out var s)
-                ? s : 0;
+                ? s : -1;
         }
 
-        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var raw) ? raw : 0;
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var raw) ? raw : -1;
     }
 
     /// <summary>
     /// Parses a duration string like "200ms" or "2000ms" into milliseconds.
     /// Also supports "2s" → 2000ms.
-    /// Returns 0 if the input is null or unparseable.
+    /// Returns 0 if the input is null, or -1 if the value is present but unparseable.
     /// </summary>
     private static double ParseDurationToMs(string? value)
     {
@@ -646,28 +646,28 @@ public sealed class SchemaParser
         if (value.EndsWith("ms", StringComparison.OrdinalIgnoreCase))
         {
             return double.TryParse(value.AsSpan(0, value.Length - 2), NumberStyles.Float, CultureInfo.InvariantCulture, out var ms)
-                ? ms : 0;
+                ? ms : -1;
         }
 
         if (value.EndsWith('s'))
         {
             return double.TryParse(value.AsSpan(0, value.Length - 1), NumberStyles.Float, CultureInfo.InvariantCulture, out var s)
-                ? s * 1000.0 : 0;
+                ? s * 1000.0 : -1;
         }
 
-        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var raw) ? raw : 0;
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var raw) ? raw : -1;
     }
 
     private static double ParseOptionalDouble(string? value)
     {
         if (value is null) return 0;
-        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result) ? result : 0;
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result) ? result : -1;
     }
 
     private static int ParseOptionalInt(string? value)
     {
         if (value is null) return 0;
-        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result) ? result : 0;
+        return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result) ? result : -1;
     }
 
     // ── YAML helpers ────────────────────────────────────────────────────

--- a/src/OtelEvents.Schema/Validation/ErrorCodes.cs
+++ b/src/OtelEvents.Schema/Validation/ErrorCodes.cs
@@ -121,4 +121,7 @@ public static class ErrorCodes
 
     /// <summary>Signal match filter keys must be non-empty strings.</summary>
     public const string InvalidSignalMatchKey = "OTEL_SCHEMA_039";
+
+    /// <summary>A numeric or duration field contains a malformed (unparseable) value.</summary>
+    public const string MalformedValue = "OTEL_SCHEMA_040";
 }

--- a/src/OtelEvents.Schema/Validation/SchemaValidator.cs
+++ b/src/OtelEvents.Schema/Validation/SchemaValidator.cs
@@ -504,6 +504,21 @@ public sealed partial class SchemaValidator
 
     private static void ValidateComponent(ComponentDefinition component, List<SchemaError> errors)
     {
+        // OTEL_SCHEMA_040: Detect malformed (unparseable) numeric values.
+        // The parser returns -1 as a sentinel for values that are present but not parseable.
+        ValidateMalformedValue(component.Name, "healthyAbove", component.HealthyAbove, errors);
+        ValidateMalformedValue(component.Name, "degradedAbove", component.DegradedAbove, errors);
+        ValidateMalformedValue(component.Name, "minimumSignals", component.MinimumSignals, errors);
+        ValidateMalformedValue(component.Name, "window", component.WindowSeconds, errors);
+        ValidateMalformedValue(component.Name, "cooldown", component.CooldownSeconds, errors);
+
+        if (component.ResponseTime is not null)
+        {
+            ValidateMalformedValue(component.Name, "responseTime.percentile", component.ResponseTime.Percentile, errors);
+            ValidateMalformedValue(component.Name, "responseTime.degradedAfter", component.ResponseTime.DegradedAfterMs, errors);
+            ValidateMalformedValue(component.Name, "responseTime.unhealthyAfter", component.ResponseTime.UnhealthyAfterMs, errors);
+        }
+
         // OTEL_SCHEMA_033: Component name format
         if (!ComponentNameRegex().IsMatch(component.Name))
         {
@@ -544,8 +559,8 @@ public sealed partial class SchemaValidator
             });
         }
 
-        // OTEL_SCHEMA_036: minimumSignals >= 1
-        if (component.MinimumSignals > 0 && component.MinimumSignals < 1)
+        // OTEL_SCHEMA_036: minimumSignals >= 1 (reject negative values from malformed YAML)
+        if (component.MinimumSignals < 0)
         {
             errors.Add(new SchemaError
             {
@@ -587,6 +602,38 @@ public sealed partial class SchemaValidator
                     });
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Reports a validation error if a parsed numeric value is -1 (sentinel for malformed YAML).
+    /// </summary>
+    private static void ValidateMalformedValue(string componentName, string fieldName, double value, List<SchemaError> errors)
+    {
+        // The parser uses -1 as a sentinel for present-but-unparseable values.
+        // A value of 0 means the field was absent (null in YAML), which is valid (uses default).
+        if (value < 0)
+        {
+            errors.Add(new SchemaError
+            {
+                Code = ErrorCodes.MalformedValue,
+                Message = $"Component '{componentName}' has a malformed value for '{fieldName}'. Expected a valid number or duration."
+            });
+        }
+    }
+
+    /// <summary>
+    /// Reports a validation error if a parsed integer value is -1 (sentinel for malformed YAML).
+    /// </summary>
+    private static void ValidateMalformedValue(string componentName, string fieldName, int value, List<SchemaError> errors)
+    {
+        if (value < 0)
+        {
+            errors.Add(new SchemaError
+            {
+                Code = ErrorCodes.MalformedValue,
+                Message = $"Component '{componentName}' has a malformed value for '{fieldName}'. Expected a valid integer."
+            });
         }
     }
 }

--- a/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
+++ b/src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="OtelEvents.Subscriptions.Tests" />
+    <InternalsVisibleTo Include="OtelEvents.Health" />
+    <InternalsVisibleTo Include="OtelEvents.Health.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/OtelEvents.Health.Tests/HealthBossBuilderTests.cs
+++ b/tests/OtelEvents.Health.Tests/HealthBossBuilderTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using OtelEvents.Health;
 using OtelEvents.Health.Contracts;
+using OtelEvents.Schema.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -721,5 +722,68 @@ public sealed class HealthBossBuilderTests
         });
 
         act.Should().Throw<ArgumentException>();
+    }
+
+    // ──────────────────────────────────────────────
+    // Finding 4: Cooldown builder method
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ComponentBuilder_Cooldown_sets_CooldownBeforeTransition()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsHealth(opts =>
+        {
+            opts.AddComponent("redis", c => c.Cooldown(TimeSpan.FromSeconds(60)));
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var opts = provider.GetRequiredService<IOptions<HealthBossOptions>>().Value;
+
+        opts.Components.Should().ContainKey("redis");
+        opts.Components["redis"].Policy.CooldownBeforeTransition
+            .Should().Be(TimeSpan.FromSeconds(60));
+    }
+
+    [Fact]
+    public void ComponentBuilder_Cooldown_default_is_30_seconds()
+    {
+        var services = new ServiceCollection();
+        services.AddOtelEventsHealth(opts =>
+        {
+            opts.AddComponent("redis"); // no cooldown specified
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var opts = provider.GetRequiredService<IOptions<HealthBossOptions>>().Value;
+
+        opts.Components["redis"].Policy.CooldownBeforeTransition
+            .Should().Be(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void AddOtelEventsHealth_from_ComponentDefinition_wires_CooldownSeconds()
+    {
+        var components = new List<ComponentDefinition>
+        {
+            new()
+            {
+                Name = "orders-db",
+                CooldownSeconds = 45,
+                Signals =
+                [
+                    new SignalMapping { Event = "http.request.completed" }
+                ]
+            }
+        };
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsHealth(components);
+
+        using var provider = services.BuildServiceProvider();
+        var opts = provider.GetRequiredService<IOptions<HealthBossOptions>>().Value;
+
+        opts.Components["orders-db"].Policy.CooldownBeforeTransition
+            .Should().Be(TimeSpan.FromSeconds(45));
     }
 }

--- a/tests/OtelEvents.Health.Tests/HealthBossBuilderTests.cs
+++ b/tests/OtelEvents.Health.Tests/HealthBossBuilderTests.cs
@@ -113,7 +113,7 @@ public sealed class HealthBossBuilderTests
     {
         var services = new ServiceCollection();
 
-        var act = () => services.AddOtelEventsHealth(null!);
+        var act = () => services.AddOtelEventsHealth((Action<HealthBossOptions>)null!);
 
         act.Should().Throw<ArgumentNullException>()
             .And.ParamName.Should().Be("configure");

--- a/tests/OtelEvents.Health.Tests/HealthSignalBridgeDiTests.cs
+++ b/tests/OtelEvents.Health.Tests/HealthSignalBridgeDiTests.cs
@@ -1,0 +1,149 @@
+// <copyright file="HealthSignalBridgeDiTests.cs" company="OtelEvents">
+// Copyright (c) OtelEvents. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OtelEvents.Health.Contracts;
+using OtelEvents.Schema.Models;
+using OtelEvents.Subscriptions;
+
+namespace OtelEvents.Health.Tests;
+
+/// <summary>
+/// Integration tests for <see cref="HealthSignalBridge"/> DI wiring.
+/// Verifies that the full pipeline works without manual Bind() calls —
+/// the bridge lazily resolves <see cref="ISignalRecorder"/> from <see cref="IServiceProvider"/>.
+/// </summary>
+public sealed class HealthSignalBridgeDiTests
+{
+    [Fact]
+    public void AddOtelEventsHealth_with_components_registers_bridge_as_singleton()
+    {
+        var components = new List<ComponentDefinition>
+        {
+            new()
+            {
+                Name = "orders-db",
+                Signals =
+                [
+                    new SignalMapping { Event = "http.request.completed" }
+                ]
+            }
+        };
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsHealth(components);
+
+        using var provider = services.BuildServiceProvider();
+
+        var bridge = provider.GetService<HealthSignalBridge>();
+        bridge.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Bridge_resolves_ISignalRecorder_lazily_from_ServiceProvider()
+    {
+        var components = new List<ComponentDefinition>
+        {
+            new()
+            {
+                Name = "orders-db",
+                Signals =
+                [
+                    new SignalMapping { Event = "http.request.completed" }
+                ]
+            }
+        };
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsHealth(components);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Simulate what happens at host startup: resolve all hosted services.
+        // This triggers the bridge initialization (SP injection via IHostedService factory).
+        var hostedServices = provider.GetServices<IHostedService>().ToList();
+        hostedServices.Should().NotBeEmpty("the bridge initializer must be registered as IHostedService");
+
+        // Get the bridge — should now have SP injected
+        var bridge = provider.GetRequiredService<HealthSignalBridge>();
+
+        // Fire a signal through the bridge — should resolve ISignalRecorder from SP
+        var depId = new DependencyId("orders-db");
+        var signal = components[0].Signals[0];
+        var ctx = new OtelEventContext(
+            "http.request.completed",
+            LogLevel.Information,
+            null,
+            new Dictionary<string, object?>(),
+            DateTimeOffset.UtcNow,
+            null, null, null);
+
+        // This should NOT throw. The bridge lazily resolves ISignalRecorder via SP.
+        var act = () => bridge.HandleSignal(depId, signal, ctx);
+        act.Should().NotThrow();
+
+        // Verify the signal reached the orchestrator
+        var orchestrator = provider.GetRequiredService<IHealthOrchestrator>();
+        var report = orchestrator.GetHealthReport();
+        report.Dependencies.Should().ContainSingle(d => d.DependencyId == depId);
+    }
+
+    [Fact]
+    public void Full_pipeline_no_manual_Bind_signals_reach_orchestrator()
+    {
+        // This is the CRITICAL test: end-to-end verification that
+        // signals flow from bridge → ISignalRecorder → orchestrator
+        // without anyone calling Bind() explicitly.
+        var components = new List<ComponentDefinition>
+        {
+            new()
+            {
+                Name = "redis",
+                MinimumSignals = 1, // low threshold for test
+                Signals =
+                [
+                    new SignalMapping { Event = "cache.request.completed" },
+                    new SignalMapping { Event = "cache.request.failed" }
+                ]
+            }
+        };
+
+        var services = new ServiceCollection();
+        services.AddOtelEventsHealth(components);
+
+        using var provider = services.BuildServiceProvider();
+
+        // Resolve hosted services (triggers bridge SP initialization)
+        _ = provider.GetServices<IHostedService>().ToList();
+
+        var bridge = provider.GetRequiredService<HealthSignalBridge>();
+        var depId = new DependencyId("redis");
+
+        // Fire 5 success signals
+        for (int i = 0; i < 5; i++)
+        {
+            var ctx = new OtelEventContext(
+                "cache.request.completed",
+                LogLevel.Information,
+                null,
+                new Dictionary<string, object?> { ["durationMs"] = 50.0 },
+                DateTimeOffset.UtcNow.AddSeconds(i),
+                null, null, null);
+
+            bridge.HandleSignal(depId, components[0].Signals[0], ctx);
+        }
+
+        // Verify signals reached the orchestrator's buffer
+        var orchestrator = provider.GetRequiredService<IHealthOrchestrator>();
+        var report = orchestrator.GetHealthReport();
+        report.Dependencies.Should().ContainSingle();
+
+        var dep = report.Dependencies[0];
+        dep.DependencyId.Should().Be(depId);
+        dep.LatestAssessment.TotalSignals.Should().Be(5);
+    }
+}

--- a/tests/OtelEvents.Health.Tests/HealthSignalBridgeTests.cs
+++ b/tests/OtelEvents.Health.Tests/HealthSignalBridgeTests.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OtelEvents.Health.Contracts;
 using OtelEvents.Schema.Models;
@@ -652,29 +653,40 @@ public sealed class HealthSignalBridgeTests
     }
 
     // ═══════════════════════════════════════════════════════════════
-    // 8. Bind — late binding for DI
+    // 8. Initialize — lazy DI resolution via IServiceProvider
     // ═══════════════════════════════════════════════════════════════
 
     [Fact]
-    public void Bind_SetsRecorder_AllowsHandleSignal()
+    public void Initialize_SetsServiceProvider_AllowsLazyRecorderResolution()
     {
         var recorder = new RecordingSignalRecorder();
         var component = CreateComponent("orders-db",
             CreateSignal("http.request.completed"));
         var bridge = new HealthSignalBridge([component]);
 
-        // Before bind: signal is silently dropped
+        // Before Initialize: signal is silently dropped (no SP, no recorder)
         var depId = new DependencyId("orders-db");
         var ctx1 = CreateContext("http.request.completed");
         bridge.HandleSignal(depId, component.Signals[0], ctx1);
         recorder.Recorded.Should().BeEmpty();
 
-        // Bind recorder
-        bridge.Bind(recorder);
+        // Initialize with a service provider that returns the recorder
+        var services = new ServiceCollection();
+        services.AddSingleton<ISignalRecorder>(recorder);
+        using var sp = services.BuildServiceProvider();
+        bridge.Initialize(sp);
 
-        // After bind: signal is recorded
+        // After Initialize: HandleSignal lazily resolves recorder from SP
         var ctx2 = CreateContext("http.request.completed");
         bridge.HandleSignal(depId, component.Signals[0], ctx2);
         recorder.Recorded.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Initialize_NullServiceProvider_ThrowsArgumentNullException()
+    {
+        var bridge = new HealthSignalBridge([]);
+        var act = () => bridge.Initialize(null!);
+        act.Should().Throw<ArgumentNullException>();
     }
 }

--- a/tests/OtelEvents.Health.Tests/HealthSignalBridgeTests.cs
+++ b/tests/OtelEvents.Health.Tests/HealthSignalBridgeTests.cs
@@ -1,0 +1,680 @@
+// <copyright file="HealthSignalBridgeTests.cs" company="OtelEvents">
+// Copyright (c) OtelEvents. All rights reserved.
+// </copyright>
+
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using OtelEvents.Health.Contracts;
+using OtelEvents.Schema.Models;
+using OtelEvents.Subscriptions;
+
+namespace OtelEvents.Health.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="HealthSignalBridge"/> — the auto-subscribe bridge
+/// that connects otel-events subscriptions to the Health state machine.
+/// Tests cover outcome classification, match filtering, latency extraction,
+/// signal recording, and subscription registration.
+/// </summary>
+public sealed class HealthSignalBridgeTests
+{
+    // ═══════════════════════════════════════════════════════════════
+    // Test infrastructure
+    // ═══════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Simple recording stub for <see cref="ISignalRecorder"/>.
+    /// Captures all recorded signals for assertion.
+    /// </summary>
+    private sealed class RecordingSignalRecorder : ISignalRecorder
+    {
+        public List<(DependencyId Id, HealthSignal Signal)> Recorded { get; } = [];
+
+        public void RecordSignal(DependencyId id, HealthSignal signal)
+        {
+            Recorded.Add((id, signal));
+        }
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OtelEventContext"/> for testing with the given parameters.
+    /// </summary>
+    private static OtelEventContext CreateContext(
+        string eventName,
+        Dictionary<string, object?>? attributes = null,
+        DateTimeOffset? timestamp = null)
+    {
+        return new OtelEventContext(
+            eventName: eventName,
+            logLevel: LogLevel.Information,
+            formattedMessage: null,
+            attributes: attributes ?? new Dictionary<string, object?>(),
+            timestamp: timestamp ?? DateTimeOffset.UtcNow,
+            traceId: null,
+            spanId: null,
+            exception: null);
+    }
+
+    /// <summary>
+    /// Creates a minimal <see cref="ComponentDefinition"/> for testing.
+    /// </summary>
+    private static ComponentDefinition CreateComponent(
+        string name,
+        params SignalMapping[] signals)
+    {
+        return new ComponentDefinition
+        {
+            Name = name,
+            WindowSeconds = 300,
+            HealthyAbove = 0.9,
+            DegradedAbove = 0.5,
+            MinimumSignals = 5,
+            CooldownSeconds = 30,
+            Signals = [.. signals],
+        };
+    }
+
+    /// <summary>
+    /// Creates a <see cref="SignalMapping"/> for testing.
+    /// </summary>
+    private static SignalMapping CreateSignal(
+        string eventName,
+        Dictionary<string, string>? match = null)
+    {
+        return new SignalMapping
+        {
+            Event = eventName,
+            Match = match ?? [],
+        };
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 1. Outcome classification — ClassifyOutcome
+    // ═══════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("http.request.failed", SignalOutcome.Failure)]
+    [InlineData("cosmosdb.query.failed", SignalOutcome.Failure)]
+    [InlineData("storage.upload.FAILED", SignalOutcome.Failure)]
+    public void ClassifyOutcome_FailedSuffix_ReturnsFailure(string eventName, SignalOutcome expected)
+    {
+        var result = HealthSignalBridge.ClassifyOutcome(eventName);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("cosmosdb.throttled", SignalOutcome.Failure)]
+    [InlineData("redis.THROTTLED", SignalOutcome.Failure)]
+    public void ClassifyOutcome_ThrottledSuffix_ReturnsFailure(string eventName, SignalOutcome expected)
+    {
+        var result = HealthSignalBridge.ClassifyOutcome(eventName);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("http.request.completed", SignalOutcome.Success)]
+    [InlineData("order.processing.COMPLETED", SignalOutcome.Success)]
+    public void ClassifyOutcome_CompletedSuffix_ReturnsSuccess(string eventName, SignalOutcome expected)
+    {
+        var result = HealthSignalBridge.ClassifyOutcome(eventName);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("sql.query.executed", SignalOutcome.Success)]
+    [InlineData("batch.job.EXECUTED", SignalOutcome.Success)]
+    public void ClassifyOutcome_ExecutedSuffix_ReturnsSuccess(string eventName, SignalOutcome expected)
+    {
+        var result = HealthSignalBridge.ClassifyOutcome(eventName);
+
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("http.request.started")]
+    [InlineData("batch.job.STARTED")]
+    public void ClassifyOutcome_StartedSuffix_ReturnsNull(string eventName)
+    {
+        var result = HealthSignalBridge.ClassifyOutcome(eventName);
+
+        result.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("unknown.event")]
+    [InlineData("no.suffix")]
+    [InlineData("")]
+    public void ClassifyOutcome_UnknownSuffix_ReturnsNull(string eventName)
+    {
+        var result = HealthSignalBridge.ClassifyOutcome(eventName);
+
+        result.Should().BeNull();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 2. Match filter — MatchesFilters
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void MatchesFilters_EmptyMatch_ReturnsTrue()
+    {
+        var ctx = CreateContext("http.request.completed");
+        var match = new Dictionary<string, string>();
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MatchesFilters_ExactMatch_ReturnsTrue()
+    {
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/orders",
+        });
+        var match = new Dictionary<string, string> { ["httpRoute"] = "/api/orders" };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MatchesFilters_ExactMismatch_ReturnsFalse()
+    {
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/users",
+        });
+        var match = new Dictionary<string, string> { ["httpRoute"] = "/api/orders" };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFilters_WildcardMatch_ReturnsTrue()
+    {
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/orders/123",
+        });
+        var match = new Dictionary<string, string> { ["httpRoute"] = "/api/orders/*" };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MatchesFilters_WildcardMismatch_ReturnsFalse()
+    {
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/users/456",
+        });
+        var match = new Dictionary<string, string> { ["httpRoute"] = "/api/orders/*" };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFilters_MissingAttribute_ReturnsFalse()
+    {
+        var ctx = CreateContext("http.request.completed"); // no attributes
+        var match = new Dictionary<string, string> { ["httpRoute"] = "/api/orders" };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFilters_MultipleFilters_AllMustMatch()
+    {
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/orders",
+            ["httpMethod"] = "POST",
+        });
+        var match = new Dictionary<string, string>
+        {
+            ["httpRoute"] = "/api/orders",
+            ["httpMethod"] = "POST",
+        };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MatchesFilters_MultipleFilters_OneMismatch_ReturnsFalse()
+    {
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/orders",
+            ["httpMethod"] = "GET",
+        });
+        var match = new Dictionary<string, string>
+        {
+            ["httpRoute"] = "/api/orders",
+            ["httpMethod"] = "POST",
+        };
+
+        var result = HealthSignalBridge.MatchesFilters(match, ctx);
+
+        result.Should().BeFalse();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 3. Pattern matching — MatchesPattern
+    // ═══════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("/api/orders/123", "/api/orders/*", true)]
+    [InlineData("/api/orders/", "/api/orders/*", true)]
+    [InlineData("/api/users/123", "/api/orders/*", false)]
+    [InlineData("/api/orders", "/api/orders", true)]
+    [InlineData("/api/orders", "/api/users", false)]
+    [InlineData("anything", "*", true)]
+    public void MatchesPattern_VariousInputs_ReturnsExpected(
+        string value, string pattern, bool expected)
+    {
+        var result = HealthSignalBridge.MatchesPattern(value, pattern);
+
+        result.Should().Be(expected);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 4. Latency extraction — ExtractLatency
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void ExtractLatency_DoubleDurationMs_ReturnsTimeSpan()
+    {
+        var ctx = CreateContext("test.completed", new Dictionary<string, object?>
+        {
+            ["durationMs"] = 150.5,
+        });
+
+        var result = HealthSignalBridge.ExtractLatency(ctx);
+
+        result.Should().Be(TimeSpan.FromMilliseconds(150.5));
+    }
+
+    [Fact]
+    public void ExtractLatency_LongDurationMs_ReturnsTimeSpan()
+    {
+        var ctx = CreateContext("test.completed", new Dictionary<string, object?>
+        {
+            ["durationMs"] = 200L,
+        });
+
+        var result = HealthSignalBridge.ExtractLatency(ctx);
+
+        result.Should().Be(TimeSpan.FromMilliseconds(200));
+    }
+
+    [Fact]
+    public void ExtractLatency_IntDurationMs_ReturnsTimeSpan()
+    {
+        var ctx = CreateContext("test.completed", new Dictionary<string, object?>
+        {
+            ["durationMs"] = 100,
+        });
+
+        var result = HealthSignalBridge.ExtractLatency(ctx);
+
+        result.Should().Be(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void ExtractLatency_StringDurationMs_ReturnsTimeSpan()
+    {
+        var ctx = CreateContext("test.completed", new Dictionary<string, object?>
+        {
+            ["durationMs"] = "75.5",
+        });
+
+        var result = HealthSignalBridge.ExtractLatency(ctx);
+
+        result.Should().Be(TimeSpan.FromMilliseconds(75.5));
+    }
+
+    [Fact]
+    public void ExtractLatency_NoDurationMs_ReturnsNull()
+    {
+        var ctx = CreateContext("test.completed");
+
+        var result = HealthSignalBridge.ExtractLatency(ctx);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractLatency_NonNumericDurationMs_ReturnsNull()
+    {
+        var ctx = CreateContext("test.completed", new Dictionary<string, object?>
+        {
+            ["durationMs"] = "not-a-number",
+        });
+
+        var result = HealthSignalBridge.ExtractLatency(ctx);
+
+        result.Should().BeNull();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 5. HandleSignal — end-to-end signal recording
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void HandleSignal_MatchingEvent_RecordsSignal()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.completed");
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Id.Should().Be(depId);
+        recorder.Recorded[0].Signal.Outcome.Should().Be(SignalOutcome.Success);
+    }
+
+    [Fact]
+    public void HandleSignal_NonMatchingFilter_DoesNotRecord()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed",
+                new Dictionary<string, string> { ["httpRoute"] = "/api/orders/*" }));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/users/123",
+        });
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void HandleSignal_MatchingFilter_RecordsSignal()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.failed",
+                new Dictionary<string, string> { ["httpRoute"] = "/api/orders/*" }));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.failed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/orders/456",
+        });
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Signal.Outcome.Should().Be(SignalOutcome.Failure);
+    }
+
+    [Fact]
+    public void HandleSignal_UnclassifiableEvent_DoesNotRecord()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.started"));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.started");
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void HandleSignal_WithLatency_IncludesLatencyInSignal()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["durationMs"] = 250.0,
+        });
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Signal.Latency.Should().Be(TimeSpan.FromMilliseconds(250));
+    }
+
+    [Fact]
+    public void HandleSignal_WithoutLatency_SignalHasNullLatency()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.completed");
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Signal.Latency.Should().BeNull();
+    }
+
+    [Fact]
+    public void HandleSignal_PreservesTimestamp()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var depId = new DependencyId("orders-db");
+        var fixedTime = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero);
+        var ctx = CreateContext("http.request.completed", timestamp: fixedTime);
+
+        bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Signal.Timestamp.Should().Be(fixedTime);
+    }
+
+    [Fact]
+    public void HandleSignal_NullRecorder_DoesNotThrow()
+    {
+        // Bridge created without recorder (unbound state)
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"));
+        var bridge = new HealthSignalBridge([component]);
+
+        var depId = new DependencyId("orders-db");
+        var ctx = CreateContext("http.request.completed");
+
+        var act = () => bridge.HandleSignal(depId, component.Signals[0], ctx);
+
+        act.Should().NotThrow();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 6. RegisterSubscriptions — subscription registration
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void RegisterSubscriptions_NoComponents_NoRegistrations()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var bridge = new HealthSignalBridge([], recorder);
+        var builder = new OtelEventsSubscriptionBuilder(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection());
+
+        bridge.RegisterSubscriptions(builder);
+
+        builder.Registrations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RegisterSubscriptions_SingleComponentMultipleSignals_RegistersAll()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"),
+            CreateSignal("http.request.failed"));
+        var bridge = new HealthSignalBridge([component], recorder);
+        var builder = new OtelEventsSubscriptionBuilder(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection());
+
+        bridge.RegisterSubscriptions(builder);
+
+        builder.Registrations.Should().HaveCount(2);
+        builder.Registrations[0].EventPattern.Should().Be("http.request.completed");
+        builder.Registrations[1].EventPattern.Should().Be("http.request.failed");
+    }
+
+    [Fact]
+    public void RegisterSubscriptions_MultipleComponents_RegistersAll()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var comp1 = CreateComponent("orders-db",
+            CreateSignal("order.completed"));
+        var comp2 = CreateComponent("payments-api",
+            CreateSignal("payment.completed"),
+            CreateSignal("payment.failed"));
+        var bridge = new HealthSignalBridge([comp1, comp2], recorder);
+        var builder = new OtelEventsSubscriptionBuilder(
+            new Microsoft.Extensions.DependencyInjection.ServiceCollection());
+
+        bridge.RegisterSubscriptions(builder);
+
+        builder.Registrations.Should().HaveCount(3);
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 7. End-to-end via RegisterSubscriptions → fire event → signal recorded
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task RegisteredSubscription_EventFires_SignalRecordedInCorrectComponent()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var comp1 = CreateComponent("orders-db",
+            CreateSignal("order.completed"));
+        var comp2 = CreateComponent("payments-api",
+            CreateSignal("payment.failed"));
+        var bridge = new HealthSignalBridge([comp1, comp2], recorder);
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+        bridge.RegisterSubscriptions(builder);
+
+        // Simulate event dispatch by invoking the registered lambda
+        var orderCtx = CreateContext("order.completed");
+        await builder.Registrations[0].LambdaHandler!(orderCtx, CancellationToken.None);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Id.Value.Should().Be("orders-db");
+        recorder.Recorded[0].Signal.Outcome.Should().Be(SignalOutcome.Success);
+    }
+
+    [Fact]
+    public async Task RegisteredSubscription_FailedEvent_RecordsFailure()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("payments-api",
+            CreateSignal("payment.failed"));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+        bridge.RegisterSubscriptions(builder);
+
+        var ctx = CreateContext("payment.failed");
+        await builder.Registrations[0].LambdaHandler!(ctx, CancellationToken.None);
+
+        recorder.Recorded.Should().ContainSingle();
+        recorder.Recorded[0].Signal.Outcome.Should().Be(SignalOutcome.Failure);
+    }
+
+    [Fact]
+    public async Task RegisteredSubscription_MatchFilter_OnlyRecordsMatching()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed",
+                new Dictionary<string, string> { ["httpRoute"] = "/api/orders/*" }));
+        var bridge = new HealthSignalBridge([component], recorder);
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        var builder = new OtelEventsSubscriptionBuilder(services);
+        bridge.RegisterSubscriptions(builder);
+
+        // Matching event
+        var matchCtx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/orders/123",
+        });
+        await builder.Registrations[0].LambdaHandler!(matchCtx, CancellationToken.None);
+
+        // Non-matching event
+        var noMatchCtx = CreateContext("http.request.completed", new Dictionary<string, object?>
+        {
+            ["httpRoute"] = "/api/users/123",
+        });
+        await builder.Registrations[0].LambdaHandler!(noMatchCtx, CancellationToken.None);
+
+        recorder.Recorded.Should().ContainSingle("only the matching event should be recorded");
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // 8. Bind — late binding for DI
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Bind_SetsRecorder_AllowsHandleSignal()
+    {
+        var recorder = new RecordingSignalRecorder();
+        var component = CreateComponent("orders-db",
+            CreateSignal("http.request.completed"));
+        var bridge = new HealthSignalBridge([component]);
+
+        // Before bind: signal is silently dropped
+        var depId = new DependencyId("orders-db");
+        var ctx1 = CreateContext("http.request.completed");
+        bridge.HandleSignal(depId, component.Signals[0], ctx1);
+        recorder.Recorded.Should().BeEmpty();
+
+        // Bind recorder
+        bridge.Bind(recorder);
+
+        // After bind: signal is recorded
+        var ctx2 = CreateContext("http.request.completed");
+        bridge.HandleSignal(depId, component.Signals[0], ctx2);
+        recorder.Recorded.Should().ContainSingle();
+    }
+}

--- a/tests/OtelEvents.Health.Tests/OtelEvents.Health.Tests.csproj
+++ b/tests/OtelEvents.Health.Tests/OtelEvents.Health.Tests.csproj
@@ -25,6 +25,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OtelEvents.Health\OtelEvents.Health.csproj" />
+    <ProjectReference Include="..\..\src\OtelEvents.Schema\OtelEvents.Schema.csproj" />
+    <ProjectReference Include="..\..\src\OtelEvents.Subscriptions\OtelEvents.Subscriptions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/OtelEvents.Health.Tests/TimerBudgetValidatorTests.cs
+++ b/tests/OtelEvents.Health.Tests/TimerBudgetValidatorTests.cs
@@ -465,4 +465,57 @@ public sealed class TimerBudgetValidatorTests
             "CooldownBelowProbeInterval",
             "JitterDominatesCooldown");
     }
+
+    // ──────────────────────────────────────────────
+    // Finding 5: Config paths use OtelEvents.Health: prefix
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Validate_all_ConfigPaths_use_OtelEventsHealth_prefix()
+    {
+        var policy = TestFixtures.DefaultPolicy with
+        {
+            CooldownBeforeTransition = TimeSpan.FromSeconds(4),
+            RecoveryProbeInterval = TimeSpan.FromSeconds(10),
+            Jitter = new JitterConfig(TimeSpan.Zero, TimeSpan.FromSeconds(3)),
+        };
+
+        var options = new TimerBudgetOptions(
+            TerminationGracePeriod: TimeSpan.FromSeconds(30),
+            LivenessFailureWindow: TimeSpan.FromSeconds(60),
+            DrainTimeout: TimeSpan.FromSeconds(20),
+            RecoveryRetryCount: 5,
+            ForceShutdownTimeout: TimeSpan.FromSeconds(15));
+
+        var warnings = _validator.Validate(SinglePolicy(policy), options);
+
+        warnings.Should().HaveCountGreaterOrEqualTo(1);
+        warnings.Should().OnlyContain(w =>
+            w.ConfigPath.StartsWith("OtelEvents.Health:", StringComparison.Ordinal),
+            "all config paths must use the OtelEvents.Health: prefix, not HealthBoss:");
+    }
+
+    [Fact]
+    public void Validate_no_ConfigPaths_reference_HealthBoss()
+    {
+        var policy = TestFixtures.DefaultPolicy with
+        {
+            CooldownBeforeTransition = TimeSpan.FromSeconds(4),
+            RecoveryProbeInterval = TimeSpan.FromSeconds(10),
+            Jitter = new JitterConfig(TimeSpan.Zero, TimeSpan.FromSeconds(3)),
+        };
+
+        var options = new TimerBudgetOptions(
+            TerminationGracePeriod: TimeSpan.FromSeconds(30),
+            LivenessFailureWindow: TimeSpan.FromSeconds(60),
+            DrainTimeout: TimeSpan.FromSeconds(20),
+            RecoveryRetryCount: 5,
+            ForceShutdownTimeout: TimeSpan.FromSeconds(15));
+
+        var warnings = _validator.Validate(SinglePolicy(policy), options);
+
+        warnings.Should().NotContain(w =>
+            w.ConfigPath.Contains("HealthBoss", StringComparison.OrdinalIgnoreCase),
+            "stale HealthBoss: references should be replaced with OtelEvents.Health:");
+    }
 }

--- a/tests/OtelEvents.Schema.Tests/ComponentParserTests.cs
+++ b/tests/OtelEvents.Schema.Tests/ComponentParserTests.cs
@@ -762,4 +762,179 @@ public class ComponentParserTests
             ]
         };
     }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Finding 2: Malformed YAML values — parse sentinel & validation
+    // ═══════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData("minimumSignals: abc")]
+    [InlineData("minimumSignals: true")]
+    [InlineData("minimumSignals: 1.5")]
+    public void Parse_MalformedMinimumSignals_ReturnsSentinel(string malformedField)
+    {
+        var yaml = $$"""
+            {{MinimalSchemaPrefix}}
+            components:
+              orders-db:
+                {{malformedField}}
+                signals:
+                  - event: "http.request.completed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+        Assert.True(result.IsSuccess);
+
+        var component = result.Document!.Components[0];
+        Assert.Equal(-1, component.MinimumSignals);
+    }
+
+    [Theory]
+    [InlineData("healthyAbove: abc")]
+    [InlineData("degradedAbove: not_a_number")]
+    public void Parse_MalformedThreshold_ReturnsSentinel(string malformedField)
+    {
+        ArgumentNullException.ThrowIfNull(malformedField);
+
+        var yaml = $$"""
+            {{MinimalSchemaPrefix}}
+            components:
+              orders-db:
+                {{malformedField}}
+                signals:
+                  - event: "http.request.completed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+        Assert.True(result.IsSuccess);
+
+        var component = result.Document!.Components[0];
+        if (malformedField.StartsWith("healthyAbove", StringComparison.Ordinal))
+            Assert.Equal(-1, component.HealthyAbove);
+        else
+            Assert.Equal(-1, component.DegradedAbove);
+    }
+
+    [Theory]
+    [InlineData("window: abc")]
+    [InlineData("window: nots")]
+    [InlineData("cooldown: xyz")]
+    public void Parse_MalformedDuration_ReturnsSentinel(string malformedField)
+    {
+        ArgumentNullException.ThrowIfNull(malformedField);
+
+        var yaml = $$"""
+            {{MinimalSchemaPrefix}}
+            components:
+              orders-db:
+                {{malformedField}}
+                signals:
+                  - event: "http.request.completed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+        Assert.True(result.IsSuccess);
+
+        var component = result.Document!.Components[0];
+        if (malformedField.StartsWith("window", StringComparison.Ordinal))
+            Assert.True(component.WindowSeconds < 0, "Malformed window should return -1 sentinel");
+        else
+            Assert.True(component.CooldownSeconds < 0, "Malformed cooldown should return -1 sentinel");
+    }
+
+    [Fact]
+    public void Validate_MalformedMinimumSignals_ReportsMalformedValueError()
+    {
+        var yaml = $$"""
+            {{MinimalSchemaPrefix}}
+            components:
+              orders-db:
+                minimumSignals: abc
+                signals:
+                  - event: "http.request.completed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+        Assert.True(result.IsSuccess);
+
+        var validation = _validator.Validate(result.Document!);
+        Assert.False(validation.IsValid);
+        Assert.Contains(validation.Errors,
+            e => e.Code == ErrorCodes.MalformedValue && e.Message.Contains("minimumSignals"));
+    }
+
+    [Fact]
+    public void Validate_MalformedHealthyAbove_ReportsMalformedValueError()
+    {
+        var yaml = $$"""
+            {{MinimalSchemaPrefix}}
+            components:
+              orders-db:
+                healthyAbove: xyz
+                signals:
+                  - event: "http.request.completed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+        Assert.True(result.IsSuccess);
+
+        var validation = _validator.Validate(result.Document!);
+        Assert.False(validation.IsValid);
+        Assert.Contains(validation.Errors,
+            e => e.Code == ErrorCodes.MalformedValue && e.Message.Contains("healthyAbove"));
+    }
+
+    [Fact]
+    public void Validate_MalformedWindow_ReportsMalformedValueError()
+    {
+        var yaml = $$"""
+            {{MinimalSchemaPrefix}}
+            components:
+              orders-db:
+                window: notaduration
+                signals:
+                  - event: "http.request.completed"
+            """;
+
+        var result = _parser.Parse(yaml, yaml.Length);
+        Assert.True(result.IsSuccess);
+
+        var validation = _validator.Validate(result.Document!);
+        Assert.False(validation.IsValid);
+        Assert.Contains(validation.Errors,
+            e => e.Code == ErrorCodes.MalformedValue && e.Message.Contains("window"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Finding 3: Negative minimumSignals validation (was dead code)
+    // ═══════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Validate_NegativeMinimumSignals_ReportsError()
+    {
+        // Simulate a component with negative minimumSignals (sentinel from malformed parse)
+        var doc = CreateDocWithComponent(new ComponentDefinition
+        {
+            Name = "test-component",
+            MinimumSignals = -1,
+            Signals = [new SignalMapping { Event = "http.request.completed" }]
+        });
+
+        var validation = _validator.Validate(doc);
+        Assert.False(validation.IsValid);
+        Assert.Contains(validation.Errors,
+            e => e.Code == ErrorCodes.InvalidMinimumSignals ||
+                 e.Code == ErrorCodes.MalformedValue);
+    }
+
+    private static SchemaDocument CreateDocWithComponent(ComponentDefinition component) => new()
+    {
+        Schema = new SchemaHeader
+        {
+            Name = "Test",
+            Version = "1.0.0",
+            Namespace = "Test.Ns"
+        },
+        Components = [component]
+    };
 }


### PR DESCRIPTION
## Summary

Bridge between otel-events subscriptions and the Health state machine (Issue #56). When events fire, they automatically become health signals based on YAML `components:` configuration.

### Prerequisites merged
- `feat/health-core` (PR #60) — OtelEvents.Health package with state machine
- `feat/yaml-components-parser` (PR #61) — YAML components: block parser

### What's new

#### `HealthSignalBridge` (`src/OtelEvents.Health/HealthSignalBridge.cs`)
Core bridge class that:
1. Takes `List<ComponentDefinition>` from parsed YAML
2. Registers otel-events subscriptions for each component's signal mappings
3. When events match (name + optional `match:` filters), classifies outcome and records health signals

#### Event name → SignalOutcome convention
| Suffix | Outcome |
|--------|---------|
| `*.failed`, `*.throttled` | `Failure` |
| `*.completed`, `*.executed` | `Success` |
| `*.started` | Skip (timing marker) |

#### Match filters
- Supports exact match and trailing `*` wildcard on attribute values
- All filters use AND logic — every filter must match
- Missing attributes cause filter to fail

#### Latency extraction
- Reads `durationMs` attribute from event context
- Supports `double`, `long`, `int`, `float`, and parseable `string` values

#### DI extension overloads (`OtelEventsHealthExtensions.cs`)
```csharp
// From YAML file path
builder.Services.AddOtelEventsHealth("health.otel.yaml");

// From pre-parsed component definitions
builder.Services.AddOtelEventsHealth(schemaDoc.Components);
```

### Files changed
| File | Change |
|------|--------|
| `src/OtelEvents.Health/HealthSignalBridge.cs` | **New** — core bridge class |
| `src/OtelEvents.Health/OtelEventsHealthExtensions.cs` | Extended with 2 new overloads |
| `src/OtelEvents.Health/OtelEvents.Health.csproj` | Added Schema + Subscriptions references |
| `src/OtelEvents.Subscriptions/OtelEvents.Subscriptions.csproj` | Added InternalsVisibleTo for Health |
| `tests/OtelEvents.Health.Tests/HealthSignalBridgeTests.cs` | **New** — 33 unit tests |
| `tests/OtelEvents.Health.Tests/OtelEvents.Health.Tests.csproj` | Added Schema + Subscriptions references |
| `tests/OtelEvents.Health.Tests/HealthBossBuilderTests.cs` | Fixed overload ambiguity (cast null) |

### Tests (33 new, all passing)
- Outcome classification: `*.failed` → Failure, `*.completed` → Success, etc.
- Match filters: exact, wildcard, missing attribute, multiple filters
- Latency extraction: double, long, int, string, missing
- HandleSignal: matching/non-matching events, unclassifiable, with/without latency
- Subscription registration: no components, single, multiple
- End-to-end: event fires → subscription matches → signal recorded
- Late binding: null recorder → bind → signal recorded

Closes #56