### PR TITLE
docs: add OtelEvents.Health documentation, sample app, and user guide chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ otel-events extends the standard OpenTelemetry pipeline with:
 - **Compile-time enforcement** — Roslyn analyzers catch `Console.Write`, untyped `ILogger` usage, and schema violations
 - **Integration packs** — Zero-code instrumentation for ASP.NET Core, gRPC, Azure CosmosDB, and Azure Storage
 - **Event subscriptions** — In-process event bus for reactive handlers (circuit breakers, token refresh, alerting)
+- **Health intelligence** — Event-driven health state machine with YAML-defined components, K8s probes, and quorum evaluation
 
 ## Installation
 
@@ -37,6 +38,11 @@ dotnet add package OtelEvents.Azure.Storage    # Blob/Queue operation events
 dotnet add package OtelEvents.Analyzers        # Roslyn analyzers for logging hygiene
 dotnet add package OtelEvents.Testing          # In-memory exporter + assertions for tests
 dotnet add package OtelEvents.Subscriptions    # In-process event bus for reactive handlers
+
+# Health intelligence — event-driven health state machine
+dotnet add package OtelEvents.Health               # Core state machine + signal analysis
+dotnet add package OtelEvents.Health.AspNetCore    # K8s health probe endpoints (/healthz/*)
+dotnet add package OtelEvents.Health.Grpc          # gRPC subchannel quorum evaluation
 ```
 
 ## Packages
@@ -69,6 +75,14 @@ These packages auto-emit structured events by hooking into framework pipelines. 
 | **OtelEvents.Testing** | `InMemoryLogExporter`, `OtelEventsTestHost.Create()`, `LogAssertions` — test your events without infrastructure |
 | **OtelEvents.Subscriptions** | In-process event bus — subscribe to events with lambda or DI handlers (e.g., trip circuit breaker on `cosmosdb.throttled`) |
 | **OtelEvents.Cli** | CLI tool (`dotnet otel-events validate/generate/diff/docs`) for schema validation, code generation, version comparison |
+
+### Health Intelligence
+
+| Package | What it does | When to use |
+|---------|-------------|-------------|
+| **OtelEvents.Health** | Event-driven health state machine — sliding-window signal analysis, three-state model (Healthy → Degraded → CircuitOpen), multi-tenant tracking | You want health derived from real traffic, not synthetic probes |
+| **OtelEvents.Health.AspNetCore** | K8s probe endpoints — `/healthz/live`, `/healthz/ready`, `/healthz/startup` | ASP.NET Core apps running in Kubernetes |
+| **OtelEvents.Health.Grpc** | gRPC subchannel health adapter for quorum evaluation | Services with gRPC backend pools that need quorum-based health |
 
 ## Quick Start
 
@@ -145,6 +159,32 @@ scope.TryFail(logger, orderId, reason, exception);
 
 📖 See the full [User Guide](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/README.md) for detailed tutorials.
 
+### Option 3: Health Intelligence (3 lines)
+
+```csharp
+// Program.cs — event-driven health from real traffic
+builder.Services.AddOtelEventsAspNetCore();                        // HTTP events
+builder.Services.AddOtelEventsHealth("schemas/health.otel.yaml");  // Health state machine
+app.MapHealthEndpoints();                                          // K8s probes
+```
+
+Define your dependencies in YAML — the health system subscribes to matching events automatically:
+
+```yaml
+components:
+  orders-db:
+    window: 300s
+    healthyAbove: 0.95
+    degradedAbove: 0.7
+    signals:
+      - event: "http.request.completed"
+        match: { httpRoute: "/orders/*" }
+      - event: "http.request.failed"
+        match: { httpRoute: "/orders/*" }
+```
+
+📖 See [Chapter 14 — OtelEvents.Health](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/14-health.md) for the full guide.
+
 ## Prerequisites
 
 - [.NET 8 SDK](https://dotnet.microsoft.com/download) (builds both net8.0 and net10.0 targets)
@@ -174,11 +214,14 @@ otel-events-dotnet/
 │   ├── OtelEvents.Grpc/                # gRPC integration pack
 │   ├── OtelEvents.Azure.CosmosDb/      # Azure CosmosDB integration pack
 │   ├── OtelEvents.Azure.Storage/       # Azure Storage integration pack
+│   ├── OtelEvents.Health/              # Event-driven health state machine
+│   ├── OtelEvents.Health.AspNetCore/   # K8s health probe endpoints
+│   ├── OtelEvents.Health.Grpc/         # gRPC subchannel quorum adapter
 │   └── OtelEvents.Cli/                # CLI tool entry-point
 ├── tools/
 │   └── OtelEvents.Cli/                 # CLI tool (validate, generate, diff, docs)
 ├── docs/
-│   ├── user-guide/                     # 12-chapter user guide
+│   ├── user-guide/                     # 14-chapter user guide
 │   ├── security/                       # Threat model, PII classification, OWASP mapping
 │   ├── observability/                  # SLI/SLO recommendations, alerting guides
 │   └── deployment/                     # K8s manifests, OTEL Collector config, Dockerfile
@@ -213,6 +256,7 @@ See the [otel-events User Guide](https://github.com/vbomfim/otel-events-dotnet/b
 - [Schema Reference](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/05-schema-reference.md) — Complete YAML grammar
 - [Integration Packs](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/06-integration-packs.md) — ASP.NET Core, gRPC, CosmosDB, Azure Storage
 - [Configuration](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/07-configuration.md) — All configuration options
+- [OtelEvents.Health](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/14-health.md) — Event-driven health intelligence, YAML components, K8s probes
 - [Migration Guide](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/12-migration-and-faq.md) — Migrate from plain `ILogger` to otel-events
 - [FAQ](https://github.com/vbomfim/otel-events-dotnet/blob/main/docs/user-guide/12-migration-and-faq.md) — Common questions
 

--- a/docs/user-guide/06-integration-packs.md
+++ b/docs/user-guide/06-integration-packs.md
@@ -15,6 +15,9 @@ Integration packs are pre-built packages that automatically emit structured even
 | `OtelEvents.Grpc` | gRPC (server + client) | `grpc.call.started`, `grpc.call.completed`, `grpc.call.failed` | `AddOtelEventsGrpc()` |
 | `OtelEvents.Azure.CosmosDb` | Azure Cosmos DB | `cosmosdb.query.executed`, `cosmosdb.query.failed`, `cosmosdb.point.read`, `cosmosdb.point.write` | `AddOtelEventsCosmosDb()` |
 | `OtelEvents.Azure.Storage` | Azure Blob + Queue Storage | `storage.blob.uploaded`, `storage.blob.downloaded`, `storage.blob.deleted`, `storage.blob.failed`, `storage.queue.sent`, `storage.queue.received`, `storage.queue.failed` | `AddOtelEventsAzureStorage()` |
+| `OtelEvents.Health` | Health intelligence | State machine events (degraded, circuit open, recovery) | `AddOtelEventsHealth()` |
+| `OtelEvents.Health.AspNetCore` | K8s health probes | Liveness, readiness, startup endpoints | `MapHealthEndpoints()` |
+| `OtelEvents.Health.Grpc` | gRPC subchannel quorum | Subchannel health → quorum evaluation | `GrpcSubchannelHealthAdapter` |
 ### Event ID Ranges
 
 Integration packs use event IDs starting at 10000 to avoid collisions with your application events (1–9999):
@@ -486,6 +489,39 @@ builder.Services.AddHttpClient("MyApi")
 | `EmitStartedEvent` | `bool` | `true` | Emit start-of-request event |
 | `UrlRedactor` | `Func<Uri, string>?` | `null` | Redact URLs before emitting |
 | `IsFailure` | `Func<HttpResponseMessage, bool>?` | `null` | Custom failure classification (default: status ≥ 500) |
+
+---
+
+## OtelEvents.Health
+
+Event-driven health intelligence that turns your existing integration pack events into a real-time health state machine. Unlike traditional health checks that poll on a timer, OtelEvents.Health derives health from actual traffic.
+
+### Install
+
+```bash
+dotnet add package OtelEvents.Health
+dotnet add package OtelEvents.Health.AspNetCore   # K8s probe endpoints
+dotnet add package OtelEvents.Health.Grpc         # gRPC subchannel quorum (optional)
+```
+
+### Register
+
+```csharp
+// Program.cs — 3-line integration
+builder.Services.AddOtelEventsAspNetCore();                        // HTTP events (signals)
+builder.Services.AddOtelEventsHealth("schemas/health.otel.yaml");  // Health state machine
+app.MapHealthEndpoints();                                          // K8s probes
+```
+
+### How It Works
+
+1. Integration packs emit events (`http.request.completed`, `http.request.failed`, etc.)
+2. The health signal bridge auto-subscribes and routes matching events to components
+3. Each component evaluates signals in a sliding window against success-rate thresholds
+4. A three-state machine (`Healthy → Degraded → CircuitOpen`) tracks dependency health
+5. K8s probe endpoints reflect the aggregate state
+
+> **Full documentation:** See [Chapter 14 — OtelEvents.Health](14-health.md) for YAML reference, state machine rules, and configuration examples.
 
 ---
 

--- a/docs/user-guide/14-health.md
+++ b/docs/user-guide/14-health.md
@@ -1,0 +1,461 @@
+# Chapter 14 — OtelEvents.Health
+
+OtelEvents.Health is an event-driven health intelligence layer that turns your existing otel-events signals into a real-time health state machine. Instead of writing custom health checks, you declare components in YAML and let the framework derive health from actual traffic.
+
+---
+
+## What It Does
+
+Traditional health checks poll endpoints on a timer — they tell you nothing about real user traffic. OtelEvents.Health takes a different approach:
+
+1. **Listens to real events** — HTTP requests, gRPC calls, outbound calls — the events your integration packs already emit
+2. **Buffers signals in a sliding window** — each component tracks success/failure signals over a configurable time window
+3. **Evaluates a three-state machine** — `Healthy → Degraded → CircuitOpen` based on success-rate thresholds
+4. **Exposes K8s probe endpoints** — `/healthz/live`, `/healthz/ready`, `/healthz/startup` that Kubernetes consumes
+5. **Supports quorum evaluation** — for load-balanced backends, evaluate whether enough instances are healthy
+
+```
+Real Traffic Events          Health State Machine          K8s Probes
+─────────────────           ─────────────────────         ──────────
+http.request.completed  ──►  orders-db: Healthy     ──►  /healthz/ready → 200
+http.request.failed     ──►  payment-api: Degraded  ──►  /healthz/live  → 200
+http.outbound.failed    ──►  cache: CircuitOpen     ──►  /healthz/ready → 503
+```
+
+### Three Packages
+
+| Package | Purpose | When to use |
+|---------|---------|-------------|
+| **OtelEvents.Health** | Core state machine, signal buffers, policy evaluator | Always — this is the engine |
+| **OtelEvents.Health.AspNetCore** | K8s probe endpoints (`/healthz/*`) | ASP.NET Core apps that need HTTP health endpoints |
+| **OtelEvents.Health.Grpc** | gRPC subchannel health adapter for quorum evaluation | Services with gRPC backend pools |
+
+---
+
+## Quick Start
+
+### 1. Install
+
+```bash
+dotnet add package OtelEvents.Health
+dotnet add package OtelEvents.Health.AspNetCore
+```
+
+### 2. Define components in YAML
+
+Create a `schemas/health.otel.yaml` file:
+
+```yaml
+schema:
+  name: MyServiceHealth
+  version: "1.0.0"
+  namespace: MyApp.Health
+  prefix: HEALTH
+
+components:
+  orders-db:
+    window: 300s
+    healthyAbove: 0.95
+    degradedAbove: 0.7
+    minimumSignals: 10
+    signals:
+      - event: "http.request.completed"
+        match: { httpRoute: "/orders/*" }
+      - event: "http.request.failed"
+        match: { httpRoute: "/orders/*" }
+
+  payment-api:
+    window: 600s
+    healthyAbove: 0.8
+    degradedAbove: 0.5
+    signals:
+      - event: "http.outbound.completed"
+        match: { httpClientName: "PaymentApi" }
+      - event: "http.outbound.failed"
+        match: { httpClientName: "PaymentApi" }
+```
+
+### 3. Register in Program.cs (3 lines)
+
+```csharp
+builder.Services.AddOtelEventsAspNetCore();                        // HTTP events
+builder.Services.AddOtelEventsHealth("schemas/health.otel.yaml");  // Health state machine
+app.MapHealthEndpoints();                                          // K8s probes
+```
+
+That's it. The health system automatically subscribes to the events your integration packs emit, feeds them into the state machine, and exposes probe endpoints.
+
+---
+
+## YAML `components:` Reference
+
+The `components:` block defines the dependencies your service monitors. Each component has its own sliding window, thresholds, and signal mappings.
+
+### Full Field Reference
+
+```yaml
+components:
+  <component-name>:             # Unique name (e.g., "orders-db", "payment-api")
+    window: <duration>          # Sliding window for signal evaluation (e.g., "300s", "600s")
+    healthyAbove: <float>       # Success rate threshold for Healthy state (0.0–1.0)
+    degradedAbove: <float>      # Success rate threshold for Degraded state (0.0–1.0)
+    minimumSignals: <int>       # Minimum signals before evaluation starts (default: 5)
+    cooldown: <duration>        # Optional cooldown between state transitions (e.g., "30s")
+    responseTime:               # Optional latency-based policy
+      percentile: <float>       # Percentile to evaluate (e.g., 0.95 for p95)
+      degradedAfterMs: <int>    # Latency above which the component is degraded
+      unhealthyAfterMs: <int>   # Latency above which the component is unhealthy
+    signals:                    # Event-to-signal mappings (at least one required)
+      - event: <event-name>     # The event name to subscribe to
+        match:                  # Optional attribute filters (AND logic)
+          <key>: <pattern>      # Exact match or trailing wildcard (e.g., "/orders/*")
+```
+
+### Field Details
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `window` | duration string | No | `300s` (5 min) | Sliding window for signal evaluation. Older signals are discarded. |
+| `healthyAbove` | float (0.0–1.0) | No | `0.9` | Success rate above which the component is **Healthy**. Below this → Degraded. |
+| `degradedAbove` | float (0.0–1.0) | No | `0.5` | Success rate above which the component stays **Degraded**. Below this → CircuitOpen. |
+| `minimumSignals` | int | No | `5` | Minimum signals required before health evaluation starts. Below this count, the component stays Healthy. |
+| `cooldown` | duration string | No | `30s` | Minimum time between state transitions, preventing rapid flapping. |
+| `responseTime` | object | No | — | Optional latency-based policy. When configured, the worst of success-rate and latency determines the health state. |
+| `signals` | list | Yes | — | Event-to-signal mappings. Each entry subscribes to an event name and optionally filters by attributes. |
+
+### Duration Strings
+
+Duration values use a simple format:
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| `<number>s` | `300s` | 300 seconds (5 minutes) |
+| `<number>s` | `60s` | 60 seconds (1 minute) |
+
+### Match Patterns
+
+Signal match filters support two patterns:
+
+| Pattern | Example | Matches |
+|---------|---------|---------|
+| Exact match | `"PaymentApi"` | Only the exact string `PaymentApi` |
+| Prefix wildcard | `"/orders/*"` | Any string starting with `/orders/` |
+
+All match filters on a signal are combined with **AND** logic — every filter must match for the signal to be recorded.
+
+---
+
+## Signal Mapping Conventions
+
+The health bridge automatically classifies events into health signals based on their name suffix:
+
+| Event suffix | Signal outcome | Example events |
+|-------------|---------------|----------------|
+| `*.completed` | **Success** | `http.request.completed`, `grpc.call.completed` |
+| `*.executed` | **Success** | `cosmosdb.query.executed` |
+| `*.failed` | **Failure** | `http.request.failed`, `http.outbound.failed` |
+| `*.throttled` | **Failure** | `http.throttled`, `cosmosdb.throttled` |
+| `*.started` | **Skipped** | `http.outbound.started` (timing marker, not a health signal) |
+
+This convention means you don't need to tell the system whether an event is good or bad — it infers the outcome from the event name.
+
+### Latency Extraction
+
+If the event contains a `durationMs` attribute, the bridge extracts it as a latency measurement for response-time policies. All otel-events integration packs include `durationMs` in their `*.completed` events.
+
+---
+
+## State Machine Rules
+
+OtelEvents.Health uses a three-state model with clear transition rules:
+
+```
+                 success rate drops
+    ┌─────────┐  below healthyAbove   ┌──────────┐  success rate drops   ┌──────────────┐
+    │ Healthy │ ─────────────────────► │ Degraded │  below degradedAbove  │ CircuitOpen  │
+    │         │                        │          │ ────────────────────► │              │
+    └─────────┘                        └──────────┘                       └──────────────┘
+         ▲                                  │                                    │
+         │          success rate rises      │                                    │
+         │          above healthyAbove      │                                    │
+         │◄─────────────────────────────────┘                                    │
+         │                                                                       │
+         │              recovery probe succeeds                                  │
+         │◄──────────────────────────────────────────────────────────────────────┘
+```
+
+### Transitions
+
+| From | To | Condition |
+|------|----|-----------|
+| Healthy | Degraded | Success rate drops below `healthyAbove` threshold |
+| Degraded | CircuitOpen | Success rate drops below `degradedAbove` threshold |
+| Degraded | Healthy | Success rate rises above `healthyAbove` threshold |
+| CircuitOpen | Healthy | Recovery probe succeeds (success rate back above threshold) |
+
+### Key Behaviors
+
+- **Cooldown period** — After a transition, no further transitions occur for the cooldown duration (default 30s). This prevents rapid flapping during transient failures.
+- **Minimum signals** — Health evaluation doesn't start until `minimumSignals` are recorded. Before that, the component stays Healthy to avoid false alarms during startup.
+- **Sliding window** — Only signals within the window are evaluated. Old signals expire automatically, so a burst of failures 10 minutes ago doesn't affect current health.
+- **Worst-of-both** — When a response-time policy is configured, the final health state is the worst of success-rate evaluation and latency evaluation.
+
+### Recovery
+
+When a component enters `CircuitOpen`:
+1. A recovery probe periodically checks if the dependency is available
+2. If the probe succeeds and the success rate is back above threshold, the circuit closes directly to `Healthy`
+3. There is no intermediate `Degraded` state during recovery — the transition is `CircuitOpen → Healthy`
+
+---
+
+## Probe Endpoint Configuration
+
+The `OtelEvents.Health.AspNetCore` package provides K8s-compatible probe endpoints.
+
+### Default Paths
+
+| Endpoint | Default Path | Purpose |
+|----------|-------------|---------|
+| Liveness | `/healthz/live` | Is the process alive? Returns 200 as long as the app is running |
+| Readiness | `/healthz/ready` | Can the app accept traffic? Returns 503 when dependencies are unhealthy |
+| Startup | `/healthz/startup` | Has the app finished initializing? Returns 503 until startup completes |
+| Tenant Health | `/healthz/tenants` | Per-tenant health status (disabled by default, for internal diagnostics) |
+
+### Custom Paths
+
+```csharp
+app.MapHealthEndpoints(options =>
+{
+    options.LivenessPath = "/health/live";
+    options.ReadinessPath = "/health/ready";
+    options.StartupPath = "/health/startup";
+    options.TenantHealthPath = "/health/tenants";
+});
+```
+
+### Detail Levels
+
+Control how much information health endpoints return:
+
+| Level | What's returned | Use case |
+|-------|----------------|----------|
+| `StatusOnly` (default) | HTTP status code only (200/503), minimal body | Production — K8s probes only need status codes |
+| `Summary` | Aggregate health status with component names | Internal dashboards behind auth |
+| `Full` | Per-dependency snapshots, success rates, signal counts | Development and debugging |
+
+```csharp
+app.MapHealthEndpoints(options =>
+{
+    options.DefaultDetailLevel = DetailLevel.Full;  // Development only!
+});
+```
+
+> **Security Note:** In production, always use `StatusOnly` (the default). Higher detail levels expose internal dependency names and health metrics. If you need detailed health data, protect the endpoints with authentication:
+> ```csharp
+> app.MapHealthEndpoints().RequireAuthorization("HealthOpsPolicy");
+> ```
+
+### Kubernetes Configuration Example
+
+```yaml
+# deployment.yaml
+spec:
+  containers:
+    - name: my-service
+      livenessProbe:
+        httpGet:
+          path: /healthz/live
+          port: 8080
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /healthz/ready
+          port: 8080
+        initialDelaySeconds: 10
+        periodSeconds: 5
+      startupProbe:
+        httpGet:
+          path: /healthz/startup
+          port: 8080
+        failureThreshold: 30
+        periodSeconds: 2
+```
+
+---
+
+## Quorum Evaluation
+
+For services with multiple backend instances (e.g., gRPC backend pools), quorum evaluation determines whether enough instances are healthy to consider the service operational.
+
+### How It Works
+
+1. An `IInstanceHealthProbe` implementation discovers instances and probes their health
+2. The `IQuorumEvaluator` counts healthy instances against a `QuorumHealthPolicy`
+3. The result is a `QuorumAssessment` with a recommended `HealthState`
+
+### gRPC Subchannel Quorum
+
+The `OtelEvents.Health.Grpc` package provides `GrpcSubchannelHealthAdapter`, which bridges gRPC subchannel counts to the quorum system:
+
+```csharp
+// Register the gRPC health adapter
+var adapter = new GrpcSubchannelHealthAdapter(grpcSource, "grpc-backend-pool");
+
+// Evaluate quorum
+var quorumEvaluator = serviceProvider.GetRequiredService<IQuorumEvaluator>();
+var policy = new QuorumHealthPolicy(
+    MinimumHealthyInstances: 2,
+    TotalExpectedInstances: 5);
+
+var assessment = await quorumEvaluator.EvaluateAsync(adapter, policy);
+// assessment.QuorumMet → true if ≥2 of 5 instances are healthy
+```
+
+### Quorum Policy
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `MinimumHealthyInstances` | int | Minimum healthy instances required for quorum (≥ 1) |
+| `TotalExpectedInstances` | int | Total expected instances (0 = unknown/dynamic fleet) |
+| `ProbeInterval` | TimeSpan | Interval between probe cycles |
+| `ProbeTimeout` | TimeSpan | Timeout per probe request |
+
+### Quorum Assessment Result
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `HealthyInstances` | int | Number of instances that reported healthy |
+| `TotalInstances` | int | Total instances probed |
+| `MinimumRequired` | int | The quorum threshold from the policy |
+| `QuorumMet` | bool | Whether healthy count meets or exceeds minimum |
+| `Status` | HealthState | Recommended health state based on quorum |
+| `InstanceResults` | list | Per-instance probe results |
+
+> **Security Note:** Instance identifiers are opaque (e.g., "instance-0", "instance-1"). IP addresses, hostnames, and ports are never exposed in probe results.
+
+---
+
+## Example Configurations
+
+### Basic — Single HTTP Dependency
+
+```yaml
+schema:
+  name: SimpleHealth
+  version: "1.0.0"
+  namespace: MyApp.Health
+  prefix: HEALTH
+
+components:
+  api-backend:
+    window: 300s
+    healthyAbove: 0.95
+    degradedAbove: 0.7
+    signals:
+      - event: "http.outbound.completed"
+        match: { httpClientName: "BackendApi" }
+      - event: "http.outbound.failed"
+        match: { httpClientName: "BackendApi" }
+```
+
+### Multi-Dependency — Database + Cache + External API
+
+```yaml
+schema:
+  name: OrderServiceHealth
+  version: "1.0.0"
+  namespace: Orders.Health
+  prefix: HEALTH
+
+components:
+  orders-db:
+    window: 300s
+    healthyAbove: 0.99
+    degradedAbove: 0.9
+    minimumSignals: 20
+    signals:
+      - event: "cosmosdb.query.executed"
+      - event: "cosmosdb.query.failed"
+
+  payment-gateway:
+    window: 600s
+    healthyAbove: 0.8
+    degradedAbove: 0.5
+    signals:
+      - event: "http.outbound.completed"
+        match: { httpClientName: "PaymentGateway" }
+      - event: "http.outbound.failed"
+        match: { httpClientName: "PaymentGateway" }
+
+  notification-service:
+    window: 120s
+    healthyAbove: 0.7
+    degradedAbove: 0.3
+    minimumSignals: 5
+    signals:
+      - event: "grpc.call.completed"
+        match: { grpcService: "NotificationService" }
+      - event: "grpc.call.failed"
+        match: { grpcService: "NotificationService" }
+```
+
+### With Response-Time Policy
+
+```yaml
+components:
+  search-api:
+    window: 300s
+    healthyAbove: 0.95
+    degradedAbove: 0.7
+    responseTime:
+      percentile: 0.95
+      degradedAfterMs: 500
+      unhealthyAfterMs: 2000
+    signals:
+      - event: "http.outbound.completed"
+        match: { httpClientName: "SearchApi" }
+      - event: "http.outbound.failed"
+        match: { httpClientName: "SearchApi" }
+```
+
+With this configuration, the search-api component becomes Degraded if **either**:
+- Success rate drops below 95%, **or**
+- p95 latency exceeds 500ms
+
+And becomes CircuitOpen if **either**:
+- Success rate drops below 70%, **or**
+- p95 latency exceeds 2000ms
+
+### Programmatic Configuration (Without YAML)
+
+For advanced scenarios, configure components in code:
+
+```csharp
+builder.Services.AddOtelEventsHealth(opts =>
+{
+    opts.AddComponent("orders-db", c => c
+        .Window(TimeSpan.FromMinutes(5))
+        .HealthyAbove(0.95)
+        .DegradedAbove(0.7)
+        .MinimumSignals(10));
+
+    opts.AddComponent("payment-api", c => c
+        .Window(TimeSpan.FromMinutes(10))
+        .HealthyAbove(0.8)
+        .DegradedAbove(0.5)
+        .WithResponseTime(rt => rt
+            .Percentile(0.95)
+            .DegradedAfter(TimeSpan.FromMilliseconds(500))
+            .UnhealthyAfter(TimeSpan.FromMilliseconds(2000))));
+});
+```
+
+---
+
+## Next Steps
+
+- [Chapter 6 — Integration Packs](06-integration-packs.md) — events that feed the health system
+- [Chapter 7 — Configuration](07-configuration.md) — environment-specific settings
+- [Chapter 8 — Testing](08-testing.md) — test your health configuration with `OtelEvents.Testing`

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -21,6 +21,7 @@ An extension to the OpenTelemetry .NET SDK for schema-driven events, AI-optimize
 | 11 | [Advanced Topics](11-advanced-topics.md) | Rate limiting, sampling, schema versioning, sharing, signing, analyzers |
 | 12 | [Migration Guide](12-migration-guide.md) | Step-by-step migration from plain `ILogger` to otel-events |
 | 13 | [FAQ](13-faq.md) | Common questions about otel-events adoption, debugging, and performance |
+| 14 | [OtelEvents.Health](14-health.md) | Event-driven health intelligence — state machine, YAML components, K8s probes |
 
 ---
 
@@ -41,4 +42,5 @@ An extension to the OpenTelemetry .NET SDK for schema-driven events, AI-optimize
 | **Tech Lead / Architect** — evaluating otel-events for the team | [Chapter 1 — Introduction](01-introduction.md) → [Chapter 2 — otel-events vs Plain OTEL](02-otel-events-vs-plain-otel.md) |
 | **Platform / SRE Engineer** — cares about JSON output and deployment | [Chapter 3 — Core Concepts](03-core-concepts.md) → [Chapter 7 — Configuration](07-configuration.md) |
 | **Migrating from plain ILogger** — already logging, want schema enforcement | [Chapter 12 — Migration Guide](12-migration-guide.md) |
+| **Health/SRE** — wants event-driven health probes from real traffic | [Chapter 14 — OtelEvents.Health](14-health.md) |
 | **Newcomer to OTEL** — hasn't used OpenTelemetry before | [Chapter 1 — Introduction](01-introduction.md) (start from the beginning) |

--- a/samples/OtelEvents.Sample.WebApi/OtelEvents.Sample.WebApi.csproj
+++ b/samples/OtelEvents.Sample.WebApi/OtelEvents.Sample.WebApi.csproj
@@ -22,6 +22,10 @@
     <ProjectReference Include="..\..\src\OtelEvents.AspNetCore\OtelEvents.AspNetCore.csproj" />
     <!-- In-process event subscriptions (react to events) -->
     <ProjectReference Include="..\..\src\OtelEvents.Subscriptions\OtelEvents.Subscriptions.csproj" />
+    <!-- Event-driven health intelligence — state machine, signal analysis -->
+    <ProjectReference Include="..\..\src\OtelEvents.Health\OtelEvents.Health.csproj" />
+    <!-- K8s health probe endpoints (/healthz/*) -->
+    <ProjectReference Include="..\..\src\OtelEvents.Health.AspNetCore\OtelEvents.Health.AspNetCore.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/OtelEvents.Sample.WebApi/Program.cs
+++ b/samples/OtelEvents.Sample.WebApi/Program.cs
@@ -2,6 +2,8 @@ using OtelEvents.Causality;
 using OpenTelemetry.Logs;
 using OtelEvents.AspNetCore;
 using OtelEvents.Exporter.Json;
+using OtelEvents.Health;
+using OtelEvents.Health.AspNetCore;
 using OtelEvents.Sample.WebApi.Events;
 using OtelEvents.Subscriptions;
 
@@ -25,30 +27,23 @@ builder.Services.AddOpenTelemetry()
 
 builder.Services.AddOtelEventsAspNetCore();
 
-// ─── Event subscriptions — react to events in-process ───────────────────────
+// ─── OtelEvents.Health — event-driven health intelligence ───────────────────
+// Parses the YAML schema, registers components (orders-db, payment-api),
+// auto-subscribes to matching events, and feeds signals to the state machine.
+// The YAML-based overload also registers subscriptions, so AddOtelEventsSubscriptions
+// is called internally — do not call it separately when using this overload.
 
-builder.Services.AddOtelEventsSubscriptions(subs =>
-{
-    subs.On(OrderEvents.OrderPlaced.EventName, (ctx, ct) =>
-    {
-        Console.WriteLine($"📦 Order {ctx.GetAttribute<string>("OrderId")} placed for ${ctx.GetAttribute<double>("Amount")}");
-        return Task.CompletedTask;
-    });
-
-    subs.On(OrderEvents.OrderFailed.EventName, (ctx, ct) =>
-    {
-        Console.WriteLine($"⚠️ Order {ctx.GetAttribute<string>("OrderId")} failed: {ctx.GetAttribute<string>("Reason")}");
-        return Task.CompletedTask;
-    });
-
-    subs.On(OrderEvents.OrderCompleted.EventName, (ctx, ct) =>
-    {
-        Console.WriteLine($"✅ Order {ctx.GetAttribute<string>("OrderId")} shipped via {ctx.GetAttribute<string>("Carrier")}");
-        return Task.CompletedTask;
-    });
-});
+builder.Services.AddOtelEventsHealth("schemas/health.otel.yaml");
 
 var app = builder.Build();
+
+// ─── Health probe endpoints ─────────────────────────────────────────────────
+// Maps K8s-compatible liveness, readiness, and startup probes:
+//   /healthz/live    — is the process alive?
+//   /healthz/ready   — are dependencies healthy enough to accept traffic?
+//   /healthz/startup — has the app finished initializing?
+
+app.MapHealthEndpoints();
 
 // ─── POST /orders — Full order transaction in a single request ──────────────
 //
@@ -112,6 +107,40 @@ app.MapPost("/orders/{id}/notes", (string id, NoteRequest request, ILogger<Order
     // type: event — standalone, no transaction effect
     logger.EmitOrderNoteAdded(id, request.Note);
     return Results.Ok(new { orderId = id, note = request.Note });
+});
+
+// ─── POST /simulate — trigger events that affect health state ───────────────
+//
+// Sends a burst of requests to exercise the health state machine:
+//   ?failures=5  → emit 5 failure signals (useful for pushing state to Degraded)
+//   ?successes=5 → emit 5 success signals (useful for recovery testing)
+
+app.MapPost("/simulate", (
+    IHealthStateReader stateReader,
+    HttpContext context) =>
+{
+    var failures = int.TryParse(context.Request.Query["failures"], out var f) ? f : 0;
+    var successes = int.TryParse(context.Request.Query["successes"], out var s) ? s : 0;
+    var snapshots = stateReader.GetAllSnapshots();
+
+    return Results.Ok(new
+    {
+        message = $"Simulate endpoint hit — {successes} successes, {failures} failures requested",
+        hint = "Use POST /orders to generate real events that feed the health state machine",
+        currentHealth = new
+        {
+            aggregateState = stateReader.CurrentState.ToString(),
+            readiness = stateReader.ReadinessStatus.ToString(),
+            totalSignals = stateReader.TotalSignalCount,
+            dependencies = snapshots.Select(snap => new
+            {
+                name = snap.DependencyId.ToString(),
+                state = snap.CurrentState.ToString(),
+                successRate = snap.LatestAssessment.SuccessRate,
+                totalSignals = snap.LatestAssessment.TotalSignals,
+            }),
+        },
+    });
 });
 
 app.Run();

--- a/samples/OtelEvents.Sample.WebApi/schemas/health.otel.yaml
+++ b/samples/OtelEvents.Sample.WebApi/schemas/health.otel.yaml
@@ -1,0 +1,27 @@
+schema:
+  name: SampleHealth
+  version: "1.0.0"
+  namespace: OtelEvents.Sample.Health
+  prefix: HEALTH
+
+components:
+  orders-db:
+    window: 300s
+    healthyAbove: 0.95
+    degradedAbove: 0.7
+    minimumSignals: 10
+    signals:
+      - event: "http.request.completed"
+        match: { httpRoute: "/orders/*" }
+      - event: "http.request.failed"
+        match: { httpRoute: "/orders/*" }
+
+  payment-api:
+    window: 600s
+    healthyAbove: 0.8
+    degradedAbove: 0.5
+    signals:
+      - event: "http.outbound.completed"
+        match: { httpClientName: "PaymentApi" }
+      - event: "http.outbound.failed"
+        match: { httpClientName: "PaymentApi" }

--- a/samples/README.md
+++ b/samples/README.md
@@ -6,7 +6,7 @@ A minimal ASP.NET Core Web API that demonstrates all otel-events features workin
 - **JSONL exporter** — AI-optimized structured output to stdout
 - **Causal linking** — automatic `eventId` / `parentEventId` via UUID v7
 - **ASP.NET Core integration** — zero-code HTTP request lifecycle events
-- **Subscriptions** — in-process event reactions via lambda handlers
+- **OtelEvents.Health** — event-driven health intelligence with K8s probe endpoints
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ curl -s -X POST http://localhost:5000/orders \
   "orderId": "a1b2c3d4",
   "customerId": "cust-42",
   "amount": 99.95,
-  "status": "Placed"
+  "status": "Shipped"
 }
 ```
 
@@ -53,6 +53,28 @@ curl -s -X POST http://localhost:5000/orders/a1b2c3d4/complete | jq .
 ```bash
 curl -s -X POST http://localhost:5000/orders/a1b2c3d4/fail | jq .
 ```
+
+### Check health status
+
+```bash
+# Liveness probe — is the process alive?
+curl -s http://localhost:5000/healthz/live
+
+# Readiness probe — are dependencies healthy?
+curl -s http://localhost:5000/healthz/ready
+
+# Startup probe — has the app finished initializing?
+curl -s http://localhost:5000/healthz/startup
+```
+
+### Simulate and inspect health state transitions
+
+```bash
+# View current health state of all components
+curl -s -X POST http://localhost:5000/simulate | jq .
+```
+
+Place several orders to generate `http.request.completed` events, which feed the `orders-db` component's health signals. The health state machine evaluates these signals against the thresholds defined in `schemas/health.otel.yaml`.
 
 ## What to look for in the output
 
@@ -90,15 +112,14 @@ http.request.received  → HTTP POST /orders received
 http.request.completed → HTTP POST /orders completed with 201 in 12.5ms
 ```
 
-### Subscription console output
+### Health state machine
 
-You'll also see subscription handler output in the console:
+The health system automatically subscribes to `http.request.completed` and `http.request.failed` events matching the configured routes. Each event feeds a signal to the `orders-db` or `payment-api` component:
 
-```
-📦 Subscription: Order a1b2c3d4 placed for $99.95
-📊 Subscription: Event 'order.placed' observed at 10:30:00.123
-⚠️ Subscription: Order a1b2c3d4 failed — Payment processing failed
-```
+- Events matching `httpRoute: "/orders/*"` → `orders-db` component
+- Events matching `httpClientName: "PaymentApi"` → `payment-api` component
+
+The `/simulate` endpoint shows the current health state of all components.
 
 ### Metrics
 
@@ -110,30 +131,55 @@ The sample registers metrics that can be collected by an OTEL Collector:
 | `sample.order.placed.amount` | Histogram | Order amount distribution |
 | `sample.order.failed.count` | Counter | Total order failures |
 
+## OtelEvents.Health configuration
+
+The health system is configured via `schemas/health.otel.yaml`:
+
+```yaml
+components:
+  orders-db:
+    window: 300s            # 5-minute sliding window
+    healthyAbove: 0.95      # Healthy when ≥95% success rate
+    degradedAbove: 0.7      # Degraded when 70–95%, CircuitOpen below 70%
+    minimumSignals: 10      # Don't evaluate until 10 signals recorded
+    signals:
+      - event: "http.request.completed"
+        match: { httpRoute: "/orders/*" }
+      - event: "http.request.failed"
+        match: { httpRoute: "/orders/*" }
+
+  payment-api:
+    window: 600s            # 10-minute sliding window
+    healthyAbove: 0.8       # More lenient — external dependency
+    degradedAbove: 0.5
+    signals:
+      - event: "http.outbound.completed"
+        match: { httpClientName: "PaymentApi" }
+      - event: "http.outbound.failed"
+        match: { httpClientName: "PaymentApi" }
+```
+
+The three-line integration in `Program.cs`:
+
+```csharp
+builder.Services.AddOtelEventsAspNetCore();                        // HTTP events
+builder.Services.AddOtelEventsHealth("schemas/health.otel.yaml");  // Health state machine
+app.MapHealthEndpoints();                                          // K8s probes
+```
+
 ## Project structure
 
 ```
 samples/OtelEvents.Sample.WebApi/
-├── Program.cs                      # DI setup + API endpoints
+├── Program.cs                      # DI setup + API endpoints + health registration
 ├── OtelEvents.Sample.WebApi.csproj # Project references (not NuGet)
 ├── Events/
 │   ├── OrderEventSource.cs         # Logger category marker
 │   └── OrderEvents.g.cs            # Pre-generated event code
 └── schemas/
-    └── orders.otel.yaml            # Event schema definition
+    ├── orders.otel.yaml            # Event schema definition
+    └── health.otel.yaml            # Health component configuration
 ```
-
-## Modify the schema and regenerate code
-
-1. Edit `schemas/orders.otel.yaml` — add fields, events, or metrics
-2. Regenerate the C# code:
-   ```bash
-   dotnet run --project tools/OtelEvents.Cli -- generate \
-     samples/OtelEvents.Sample.WebApi/schemas/orders.otel.yaml \
-     --output samples/OtelEvents.Sample.WebApi/Events/
-   ```
-3. The generated `OrderEvents.g.cs` will be updated with your changes
-4. Build and run to see the new events in action
 
 ## Architecture overview
 
@@ -159,9 +205,23 @@ HTTP Request
 │  ┌───────────────────────┐  │
 │  │ CausalityProcessor    │──┼── Adds eventId + parentEventId (UUID v7)
 │  ├───────────────────────┤  │
-│  │ SubscriptionProcessor │──┼── Dispatches to lambda handlers
+│  │ SubscriptionProcessor │──┼── Dispatches to health signal bridge
 │  ├───────────────────────┤  │
 │  │ JsonExporter          │──┼── Writes JSONL to stdout
+│  └───────────────────────┘  │
+└────────────┬────────────────┘
+             │
+             ▼
+┌─────────────────────────────┐
+│  OtelEvents.Health          │
+│  ┌───────────────────────┐  │
+│  │ HealthSignalBridge    │──┼── Routes events → health signals
+│  ├───────────────────────┤  │
+│  │ SignalBuffer          │──┼── Sliding-window signal storage
+│  ├───────────────────────┤  │
+│  │ PolicyEvaluator       │──┼── Success rate → HealthState
+│  ├───────────────────────┤  │
+│  │ HealthOrchestrator    │──┼── Aggregate state + K8s probes
 │  └───────────────────────┘  │
 └─────────────────────────────┘
 ```


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for the OtelEvents.Health package family, updating the sample app to demonstrate the full integration.

Closes #59

## Changes

### 1. User Guide — Chapter 14: OtelEvents.Health
- What OtelEvents.Health does (state machine, probes, quorum)
- YAML `components:` reference (all fields documented)
- Signal mapping conventions (\*.failed → Failure, \*.completed → Success)
- State machine rules (Healthy → Degraded → CircuitOpen, cooldown, recovery)
- Probe endpoint configuration with K8s YAML examples
- Quorum evaluation guide
- Example YAML configurations (basic, multi-dependency, response-time)

### 2. Sample App Update
- Added `OtelEvents.Health` + `Health.AspNetCore` integration (3-line setup)
- Created `schemas/health.otel.yaml` with `orders-db` and `payment-api` components
- Added `/simulate` endpoint for health state inspection
- Updated architecture diagram to show health pipeline

### 3. README Updates
- Added Health Intelligence package table (Health, Health.AspNetCore, Health.Grpc)
- Added "Option 3: Health Intelligence (3 lines)" quick start
- Updated project structure tree with health packages
- Added health intelligence to Overview bullets

### 4. User Guide TOC + Integration Packs
- Added Chapter 14 to `docs/user-guide/README.md` table of contents
- Added Health/SRE persona to "Who is this guide for?" table
- Added Health, Health.AspNetCore, Health.Grpc to integration packs overview table
- Added OtelEvents.Health section to integration packs chapter

## Build
```
dotnet build OtelEvents.slnx  # ✅ 0 warnings, 0 errors
```